### PR TITLE
Fix/allow yml file acls to have empty lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 2019-10-16
+### Added
+* Added test cases for YML files that have missing access level blocks - for example, if someone wants to generate a policy that doesn't include "Tagging" or "Permissions Management"
+### Changed
+* Test cases to allow missing access level blocks 
 ## 2019-10-15
 ### Added
 * Unit tests for the policy template generation

--- a/policy_sentry/shared/policy.py
+++ b/policy_sentry/shared/policy.py
@@ -76,27 +76,34 @@ class ArnActionGroup:
             for category in cfg:
                 if category == 'roles_with_crud_levels':
                     for principal in cfg[category]:
-                        if principal['read'] is not None:
-                            self.add(
-                                db_session, principal['read'], "Read")
+                        if 'read' in principal.keys():
+                            if principal['read'] is not None:
+                                self.add(
+                                    db_session, principal['read'], "Read")
 
-                        if principal['write'] is not None:
-                            self.add(
-                                db_session, principal['write'], "Write")
+                        if 'write' in principal.keys():
+                            if principal['write'] is not None:
+                                self.add(
+                                    db_session, principal['write'], "Write")
 
-                        if principal['list'] is not None:
-                            self.add(
-                                db_session, principal['list'], "List")
-
-                        if principal['permissions-management'] is not None:
-                            self.add(
-                                db_session, principal['permissions-management'], "Permissions management")
-
-                        if principal['tag'] is not None:
-                            self.add(
-                                db_session, principal['tag'], "Tagging")
-        except KeyError as e:
-            print("Yaml file is missing this block: " + e.args[0])
+                        if 'list' in principal.keys():
+                            if principal['list'] is not None:
+                                self.add(
+                                    db_session, principal['list'], "List")
+                        if 'permissions-management' in principal.keys():
+                            if principal['permissions-management'] is not None:
+                                self.add(
+                                    db_session, principal['permissions-management'], "Permissions management")
+                        if 'tag' in principal.keys():
+                            if principal['tag'] is not None:
+                                self.add(
+                                    db_session, principal['tag'], "Tagging")
+        # except KeyError as e:
+        #     print("Yaml file is missing this block: " + e.args[0])
+        #     sys.exit()
+        except IndexError:
+            print("IndexError: list index out of range. This is likely due to an ARN in your list equaling ''."
+                  "Please evaluate your YML file and try again.")
             sys.exit()
 
         self.update_actions_for_raw_arn_format(db_session)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 setuptools.setup(
     name="policy_sentry",
     include_package_data=True,
-    version="0.4.3",
+    version="0.4.4",
     author="Kinnaird McQuade",
     author_email="kinnairdm@gmail.com",
     description="Generate locked-down AWS IAM Policies",

--- a/test/test_yaml_validation.py
+++ b/test/test_yaml_validation.py
@@ -65,6 +65,8 @@ valid_cfg_for_actions = {
 
 
 class YamlValidationOverallTestCase(unittest.TestCase):
+
+
     # def test_multiple_roles_in_file(self):
     #     """
     #     test_multiple_roles_in_file: write-policy when the YAML file includes multiple role blocks in the file (should only be 1)
@@ -255,34 +257,70 @@ class YamlValidationOverallTestCase(unittest.TestCase):
 
 class YamlValidationCrudTestCase(unittest.TestCase):
 
-    def test_missing_access_levels(self):
+    def test_allow_missing_access_level_categories_in_cfg(self):
         """
-        test_missing_access_levels: write-policy --crud command when YAML File is missing access levels
+        test_allow_missing_access_level_categories_in_cfg: write-policy --crud when the YAML file is missing access level categories
+        It should write a policy regardless.
         :return:
         """
-        cfg_with_missing_access_levels = {
+
+        crud_file_input = {
             "roles_with_crud_levels": [
                 {
                     "name": "RoleNameWithCRUD",
                     "description": "Why I need these privs",
                     "arn": "arn:aws:iam::559410426617:role/RiskyEC2",
+                    "read": [
+                        "arn:aws:ssm:us-east-1:123456789012:parameter/test",
+                    ],
+                    "write": [
+                        "arn:aws:ssm:us-east-1:123456789012:parameter/test",
+
+                    ],
                     "list": [
-                        "arn:aws:s3:::example-org-flow-logs",
-                        "arn:aws:s3:::example-org-sbx-vmimport/stuff"
+                        "arn:aws:ssm:us-east-1:123456789012:parameter/test",
+                    ],
+                }
+            ]
+        }
+        self.maxDiff = None
+
+        result = write_policy_with_access_levels(crud_file_input, db_session)
+        print(json.dumps(result, indent=4))
+
+    def test_empty_strings_in_access_level_categories(self):
+        """
+        test_allow_empty_access_level_categories_in_cfg: If the content of a list is an empty string, it should sysexit
+        :return:
+        """
+        crud_file_input = {
+            "roles_with_crud_levels": [
+                {
+                    "name": "RoleNameWithCRUD",
+                    "description": "Why I need these privs",
+                    "arn": "arn:aws:iam::559410426617:role/RiskyEC2",
+                    "read": [
+                        "arn:aws:ssm:us-east-1:123456789012:parameter/test",
+                    ],
+                    "write": [
+                        "arn:aws:ssm:us-east-1:123456789012:parameter/test",
+
+                    ],
+                    "list": [
+                        "arn:aws:ssm:us-east-1:123456789012:parameter/test",
                     ],
                     "tag": [
-                        "arn:aws:ssm:us-east-1:123456789012:parameter/test"
+                        ""
                     ],
                     "permissions-management": [
-                        "arn:aws:s3:::example-org-s3-access-logs"
+                        ""
                     ]
                 }
             ]
         }
-
         with self.assertRaises(SystemExit):
-            arn_action_group = ArnActionGroup()
-            arn_dict = arn_action_group.process_resource_specific_acls(cfg_with_missing_access_levels, db_session)
+            result = write_policy_with_access_levels(crud_file_input, db_session)
+            print(json.dumps(result, indent=4))
 
 
 class YamlValidationActionsTestCase(unittest.TestCase):


### PR DESCRIPTION
### Added
* Quick fix to `shared.policy.process_resource_specific_acls` so that YML files can have missing categories (but they can't have missing strings)
* Added test cases for YML files that have missing access level blocks - for example, if someone wants to generate a policy that doesn't include "Tagging" or "Permissions Management"

### Changed
* Test cases to allow missing access level blocks 