### PR TITLE
Override AWS's provided Access Levels with a YML file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * We can now override Access levels so we aren't entirely dependent upon accurate AWS documentation for proper ACLs. Fixes #8.
 * Test cases for the new Access level override functions
 * You can now supply a custom YML file as part of the initialize command to test out your own overrides (so you don't have to depend on updates to this repository if you don't want to)
-* Created `policy_sentry/shared/data/access-level-overrides-yml` for a preloaded set, based on the current known issues with AWS IAM access levels.
+* Created `policy_sentry/shared/data/access-level-overrides.yml` for a preloaded set, based on the current known issues with AWS IAM access levels.
 * Cut a new release because this is a big improvement (and because I moved around a function or two)
 
 ## 2019-10-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Changelog
+## 2019-10-18
+### Added
+* We can now override Access levels so we aren't entirely dependent upon accurate AWS documentation for proper ACLs. Fixes #8.
+* Test cases for the new Access level override functions
+* You can now supply a custom YML file as part of the initialize command to test out your own overrides (so you don't have to depend on updates to this repository if you don't want to)
+* Created `policy_sentry/shared/data/access-level-overrides-yml` for a preloaded set, based on the current known issues with AWS IAM access levels.
+* Cut a new release because this is a big improvement (and because I moved around a function or two)
+
 ## 2019-10-16
 ### Added
 * Added test cases for YML files that have missing access level blocks - for example, if someone wants to generate a policy that doesn't include "Tagging" or "Permissions Management"

--- a/policy_sentry/command/analyze_iam_policy.py
+++ b/policy_sentry/command/analyze_iam_policy.py
@@ -18,9 +18,9 @@ import pprint
 from pathlib import Path
 import os.path
 from policy_sentry.shared.database import connect_db
-from policy_sentry.shared.actions import get_actions_by_access_level
+from policy_sentry.shared.actions import get_actions_by_access_level, get_actions_from_json_policy_file
 from policy_sentry.shared.analyze import determine_actions_to_expand, determine_risky_actions, analyze
-from policy_sentry.shared.file import get_actions_from_json_policy_file, list_files_in_directory
+from policy_sentry.shared.file import list_files_in_directory
 
 
 HOME = str(Path.home())

--- a/policy_sentry/command/initialize.py
+++ b/policy_sentry/command/initialize.py
@@ -2,9 +2,13 @@
 
 import os
 import click
-from policy_sentry.shared.config import create_policy_sentry_config_directory, create_audit_directory
+from policy_sentry.shared.config import create_policy_sentry_config_directory, \
+    create_audit_directory, create_default_overrides_file
 from pathlib import Path
 from policy_sentry.shared.database import connect_db, create_database
+
+HOME = str(Path.home())
+CONFIG_DIRECTORY = '/.policy_sentry/'
 
 # https://gist.github.com/0xdabbad00/489c188a154cb1074f724dec375318b2
 ALL_AWS_SERVICES = [
@@ -191,16 +195,26 @@ ALL_AWS_SERVICES = [
 @click.command(
     short_help='Create a local database to store AWS IAM information.'
 )
-def initialize():
+@click.option(
+    '--access-level-overrides-file',
+    type=str,
+    required=False,
+    default=HOME + CONFIG_DIRECTORY + 'access-level-overrides.yml',
+    help='Path to access level overrides file, used to override the Access Levels per action provided by AWS docs'
+)
+def initialize(access_level_overrides_file):
     """
     Create a local database to store AWS IAM information, which can be used to generate IAM policies and analyze them for least privilege.
     """
+
     # Create the config directory
     database_path = create_policy_sentry_config_directory()
     # Create audit directory to host list of permissions for analyze_iam_policy
     create_audit_directory()
+    # Create overrides file, which allows us to override the Access Levels provided by AWS documentation
+    create_default_overrides_file()
     # Connect to the database at that path with sqlalchemy
     db_session = connect_db(database_path)
     # Fill in the database with data on the AWS services
-    create_database(db_session, ALL_AWS_SERVICES)
+    create_database(db_session, ALL_AWS_SERVICES, access_level_overrides_file)
     print("Created tables for all services!")

--- a/policy_sentry/shared/analyze.py
+++ b/policy_sentry/shared/analyze.py
@@ -4,8 +4,7 @@ from policyuniverse import all_permissions
 import fnmatch
 import json
 import pprint
-from policy_sentry.shared.file import get_actions_from_json_policy_file
-from policy_sentry.shared.actions import get_actions_by_access_level
+from policy_sentry.shared.actions import get_actions_by_access_level, get_actions_from_json_policy_file
 
 
 def read_risky_iam_permissions_text_file(audit_file):

--- a/policy_sentry/shared/config.py
+++ b/policy_sentry/shared/config.py
@@ -2,8 +2,10 @@
 # Default location is $HOME/.policy_sentry
 from pathlib import Path
 import os
-from policy_sentry.shared.file import read_this_file, create_directory_if_it_doesnt_exist, list_files_in_directory
+from policy_sentry.shared.file import read_this_file, create_directory_if_it_doesnt_exist, \
+    list_files_in_directory, read_yaml_file
 import shutil
+import sys
 
 HOME = str(Path.home())
 CONFIG_DIRECTORY = '/.policy_sentry/'
@@ -48,3 +50,94 @@ def create_audit_directory():
             shutil.copy(source + '/' + file, destination)
             print("copying " + file + " to " + destination)
 
+
+def create_default_overrides_file():
+    """
+    Copies over the overrides file in the config directory
+    """
+    existing_overrides_file_name = 'access-level-overrides.yml'
+    target_overrides_file_path = HOME + CONFIG_DIRECTORY + existing_overrides_file_name
+    existing_overrides_file_path = os.path.abspath(os.path.dirname(__file__)) + '/data/' + existing_overrides_file_name
+    shutil.copy(existing_overrides_file_path, target_overrides_file_path)
+    print(f"Copying overrides file {existing_overrides_file_name} to {target_overrides_file_path}")
+
+
+def get_action_access_level_overrides_from_yml(service, access_level_overrides_file_path=None):
+    """
+    Read the YML overrides file, which is formatted like: ['ec2']['permissions-management'][action_name].
+    Since the AWS Documentation is sometimes outdated, we can use this YML file to
+    override whatever they provide in their documentation.
+    """
+    if not access_level_overrides_file_path:
+        access_level_overrides_file_path = os.path.abspath(os.path.dirname(__file__)) + '/data/access-level-overrides.yml'
+    cfg = read_yaml_file(access_level_overrides_file_path)
+    if service in cfg:
+        return cfg[service]
+    else:
+        return False
+
+
+def determine_access_level_override(service, action_name, provided_access_level, service_override_config):
+    """
+    override_config
+    :param service: service, like iam
+    :param action_name: action name, like ListUsers
+    :param provided_access_level: The access level provided in the scraping process
+    :param service_override_config: Specific to each service. returned by get_action_overrides_from_yml
+    :return:
+    """
+    # overrides = get_action_overrides_from_yml(service)
+    # To reduce memory, this should be used in the table building,
+    # and then run the rest of this for if else statement eval later.
+    # Using str.lower to make sure we don't get failing cases if there are minor capitalization differences
+    if str.lower(provided_access_level) == str.lower("Read"):
+        override_decision = override_access_level(service_override_config, action_name, "Read")
+    elif str.lower(provided_access_level) == str.lower("Write"):
+        override_decision = override_access_level(service_override_config, action_name, "Write")
+    elif str.lower(provided_access_level) == str.lower("List"):
+        override_decision = override_access_level(service_override_config, action_name, "List")
+    elif str.lower(provided_access_level) == str.lower("Permissions management"):
+        override_decision = override_access_level(service_override_config, action_name, "Permissions management")
+    elif str.lower(provided_access_level) == str.lower("Tagging"):
+        override_decision = override_access_level(service_override_config, action_name, "Tagging")
+    else:
+        print(f"Unknown error - determine_override_status() can't determine the access level of"
+              f" {service}:{action_name} during the scraping process. The provided access level "
+              f"was {provided_access_level}. Exiting...")
+        sys.exit()
+    return override_decision
+
+
+def override_access_level(service_override_config, action_name, provided_access_level):
+    """
+    Given the service-specific override config, determine whether or not the
+    override config tells us to override the access level in the documentation.
+    :param service_override_config: Given that the name
+    :param action_name: The name of the action
+    :param provided_access_level: Read, Write, List, Tagging, or 'Permissions management'.
+    :return:
+    """
+    real_access_level = []  # This will hold the real access level in index 0
+    for i in range(len(service_override_config.keys())):
+        keys = list(service_override_config.keys())
+        actions_list = service_override_config[keys[i]]
+        # If it exists in the list, then set the real_access_level to the key (key is read, write, list, etc.)
+        # Once we meet this condition, break the loop so we can return the value
+        if str.lower(action_name) in actions_list:
+            real_access_level.append(keys[i])
+            break
+        else:
+            continue
+    # first index will contain the access level given in the override config for that action.
+    # since we break the loop, we know it only contains one value.
+    if len(real_access_level) > 0:
+        # If AWS hasn't fixed their documentation yet, then our YAML override cfg will not match their documentation.
+        # Therefore, accept our override instead.
+        if real_access_level[0] != provided_access_level:
+            return real_access_level[0]
+        # Otherwise, they have fixed their documentation because our override file matches their documentation.
+        # Therefore, return false because we don't need to override
+        else:
+            return False
+    else:
+        return False

--- a/policy_sentry/shared/data/access-level-overrides.yml
+++ b/policy_sentry/shared/data/access-level-overrides.yml
@@ -1,0 +1,91 @@
+# format:
+# service:
+# - actionname: "read"
+# - actionname: "write"
+# - actionname: "list"
+# - actionname: "permissions management"
+# - actionname: "Tagging"
+
+ssm:
+  Write:
+    - putparameter
+ec2:
+  Permissions management:
+    - resetsnapshotattribute
+    - createnetworkinterfacepermission
+    - deletenetworkinterfacepermission
+    - modifyvpcendpointservicepermissions
+iam:
+  Permissions management:
+    - addclientidtoopenidconnectprovider
+    - addroletoinstanceprofile
+    - addusertogroup
+    - changepassword
+    - createaccesskey
+    - createaccountalias
+    - creategroup
+    - createinstanceprofile
+    - createloginprofile
+    - createopenidconnectprovider
+    - createrole
+    - createsamlprovider
+    - createservicelinkedrole
+    - createservicespecificcredential
+    - createuser
+    - createvirtualmfadevice
+    - deactivatemfadevice
+    - deleteaccesskey
+    - deleteaccountalias
+    - deletegroup
+    - deleteinstanceprofile
+    - deleteloginprofile
+    - deleteopenidconnectprovider
+    - deleterole
+    - deletesamlprovider
+    - deletesshpublickey
+    - deleteservercertificate
+    - deleteservicelinkedrole
+    - deleteservicespecificcredential
+    - deletesigningcertificate
+    - deleteuser
+    - deletevirtualmfadevice
+    - enablemfadevice
+    - passrole
+    - removeclientidfromopenidconnectprovider
+    - removerolefrominstanceprofile
+    - removeuserfromgroup
+    - resetservicespecificcredential
+    - resyncmfadevice
+    - setsecuritytokenservicepreferences
+    - updateaccesskey
+    - updateaccountpasswordpolicy
+    - updategroup
+    - updateloginprofile
+    - updateopenidconnectproviderthumbprint
+    - updaterole
+    - updateroledescription
+    - updatesamlprovider
+    - updatesshpublickey
+    - updateservercertificate
+    - updateservicespecificcredential
+    - updatesigningcertificate
+    - updateuser
+    - uploadsshpublickey
+    - uploadservercertificate
+    - uploadsigningcertificate
+secretsmanager:
+  Write:
+    - createsecret
+ram:
+  Permissions management:
+    - acceptresourceshareinvitation
+    - associateresourceshare
+    - createresourceshare
+    - deleteresourceshare
+    - disassociateresourceshare
+    - enablesharingwithawsorganization
+    - rejectresourceshareinvitation
+    - updateresourceshare
+  Tagging:
+    - tagresource
+    - untagresource

--- a/policy_sentry/shared/database.py
+++ b/policy_sentry/shared/database.py
@@ -203,7 +203,7 @@ def build_action_table(db_session, service, access_level_overrides_file):
                                                                           access_level_overrides_cfg)
                         if override_result:
                             access_level = override_result
-                            print(f"Override: Access level for {service}:{action_name} is {access_level}")
+                            print(f"Override: Setting access level for {service}:{action_name} to {access_level}")
                         else:
                             access_level = table['data'][i][2]
                     else:

--- a/policy_sentry/shared/file.py
+++ b/policy_sentry/shared/file.py
@@ -62,59 +62,6 @@ def write_json_file(filename, json_contents):
     # return filename
 
 
-def get_actions_from_json_policy_file(json_file):
-    """
-    read the json policy file and return a list of actions
-    """
-
-    # FIXME use a try/expect here to validate the json file. I would create a generic json
-    with open(json_file) as json_file:
-        # validation function/parser as there is a lot of json floating around in this tool. [MJ]
-        data = json.load(json_file)
-        actions_list = []
-        # Multiple statements are in the 'Statement' list
-        for i in range(len(data['Statement'])):
-            try:
-                if isinstance(data['Statement'], dict):
-                    try:
-
-                        if isinstance(data['Statement']['Action'], str):
-                            actions_list.append(data['Statement']['Action'])
-                        elif isinstance(data['Statement']['Action'], list):
-                            actions_list.extend(data['Statement']['Action'])
-                        else:
-                            print("Unknown error: The 'Action' is neither a list nor a string")
-                            continue
-                    except KeyError as e:
-                        print(e)
-                        exit()
-                elif isinstance(data['Statement'], list):
-                    try:
-                        if isinstance(data['Statement'][i]['Action'], str):
-                            actions_list.append(data['Statement'][i]['Action'])
-                        elif isinstance(data['Statement'][i]['Action'], list):
-                            actions_list.extend(data['Statement'][i]['Action'])
-                        else:
-                            print("Unknown error: The 'Action' is neither a list nor a string")
-                            exit()
-                    except KeyError as e:
-                        print(e)
-                        exit()
-                else:
-                    print("Unknown error: The 'Action' is neither a list nor a string")
-                    exit()
-            except TypeError as e:
-                print(e)
-                exit()
-    try:
-        actions_list = [x.lower() for x in actions_list]
-    except AttributeError:
-        print(actions_list)
-        print("AttributeError: 'list' object has no attribute 'lower'")
-    actions_list.sort()
-    return actions_list
-
-
 def list_files_in_directory(directory):
     only_files = [f for f in listdir(directory) if isfile(join(directory, f))]
     return only_files

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 setuptools.setup(
     name="policy_sentry",
     include_package_data=True,
-    version="0.4.5",
+    version="0.5.0",
     author="Kinnaird McQuade",
     author_email="kinnairdm@gmail.com",
     description="Generate locked-down AWS IAM Policies",

--- a/test/test_access_level_overrides.py
+++ b/test/test_access_level_overrides.py
@@ -1,0 +1,32 @@
+import unittest
+from policy_sentry.shared.config import get_action_access_level_overrides_from_yml, determine_access_level_override
+
+
+class AccessLevelOverride(unittest.TestCase):
+    def test_passing_overall_iam_action_override(self):
+        """Tests iam:CreateAccessKey (in overrides file as Permissions management, but in the AWS docs as Write)"""
+        desired_result = "Permissions management"
+        action_overrides = get_action_access_level_overrides_from_yml("iam")
+        result = determine_access_level_override("iam", "CreateAccessKey", "Write", action_overrides)
+        self.assertEqual(result, desired_result)
+
+    def test_overrides_yml_config(self):
+        """Tests the format of the overrides yml file for the RAM service"""
+        desired_result = {
+            'Permissions management': [
+                'acceptresourceshareinvitation',
+                'associateresourceshare',
+                'createresourceshare',
+                'deleteresourceshare',
+                'disassociateresourceshare',
+                'enablesharingwithawsorganization',
+                'rejectresourceshareinvitation',
+                'updateresourceshare'
+            ],
+            'Tagging': [
+                'tagresource',
+                'untagresource'
+            ]
+        }
+        ram_action_overrides = get_action_access_level_overrides_from_yml("ram")
+        self.assertDictEqual(ram_action_overrides, desired_result)


### PR DESCRIPTION
## 2019-10-18
### Added
* We can now override Access levels so we aren't entirely dependent upon accurate AWS documentation for proper ACLs. Fixes #8.
* Test cases for the new Access level override functions
* You can now supply a custom YML file as part of the initialize command to test out your own overrides (so you don't have to depend on updates to this repository if you don't want to)
* Created `policy_sentry/shared/data/access-level-overrides.yml` for a preloaded set, based on the current known issues with AWS IAM access levels.
* Cutting a new release (0.5.0) because this is a big improvement (and because I moved around a function or two)
