### PR TITLE
Quick fix - added code to create policy-analysis subdirectory, which was missing from the last release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## 2019-10-19
+### Added
+* `analyze-iam-policy` Code to create policy-analysis directory, was missing with last release... added it
+### Changed
+* Removed leftover code before access-level overrides was a feature
+
 ## 2019-10-18, part 2
 ### Added
 * access-level overrides now includes a TON of overrides Fixes #18.

--- a/policy_sentry/command/initialize.py
+++ b/policy_sentry/command/initialize.py
@@ -3,7 +3,7 @@
 import os
 import click
 from policy_sentry.shared.config import create_policy_sentry_config_directory, \
-    create_audit_directory, create_default_overrides_file
+    create_audit_directory, create_default_overrides_file, create_policy_analysis_directory
 from pathlib import Path
 from policy_sentry.shared.database import connect_db, create_database
 
@@ -209,6 +209,8 @@ def initialize(access_level_overrides_file):
 
     # Create the config directory
     database_path = create_policy_sentry_config_directory()
+    # Create the directory to download IAM policies to
+    create_policy_analysis_directory()
     # Create audit directory to host list of permissions for analyze_iam_policy
     create_audit_directory()
     # Create overrides file, which allows us to override the Access Levels provided by AWS documentation

--- a/policy_sentry/shared/actions.py
+++ b/policy_sentry/shared/actions.py
@@ -63,19 +63,6 @@ def get_actions_by_access_level(db_session, actions_list, access_level):
         else:
             # Just take the first result
             new_actions_list.append(action)
-        # Permissions management should also include IAM Write actions, not just IAM Permissions Management
-        if access_level == "permissions-management" and service == "iam":
-            query_iam_write_access_level = db_session.query(ActionTable).filter(
-                and_(ActionTable.service.like(service),
-                     ActionTable.name.like(str.lower(action_name)),
-                     ActionTable.access_level.like("Write")
-                     ))
-            first_result = query_actions_access_level.first()
-            if first_result is None:
-                pass
-            else:
-                # Just take the first result
-                new_actions_list.append(action)
     return new_actions_list
 
 

--- a/policy_sentry/shared/config.py
+++ b/policy_sentry/shared/config.py
@@ -51,6 +51,16 @@ def create_audit_directory():
             print("copying " + file + " to " + destination)
 
 
+def create_policy_analysis_directory():
+    """
+    Creates directory for analyze_iam_policy policies.
+    """
+    policy_analysis_directory_path = HOME + CONFIG_DIRECTORY + 'policy-analysis'
+    if os.path.exists(policy_analysis_directory_path):
+        pass
+    else:
+        os.mkdir(policy_analysis_directory_path)
+
 def create_default_overrides_file():
     """
     Copies over the overrides file in the config directory


### PR DESCRIPTION
### Added
* `analyze-iam-policy` - added code to create policy-analysis subdirectory, which was missing with last release

### Changed
* Removed leftover code before access-level overrides was a feature