### PR TITLE
Database Query from CLI capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 2019-11-13
+### Changed
+* Added `--list-arn-types` under the query command.
+  - This allows the user to query available ARN types and RAW ARN pairs
+  - Added test case for the new query command
 ## 2019-11-08
 ### Added
 * Query capability to assist users in identifying actions to supply in future #16 feature

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 2019-11-07
+### Added
+* Query capabilities for conditions table.
 ## 2019-10-24
 ### Added
 * Added boto3 and botocore to setup.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ### Added
 * Query capabilities for conditions table.
 * Query capabilities for ARN table.
+* Query capabilities for action table. Needs enhancement.
+### Changed
+* Fixed naming of a few unit tests to improve output in nosetests.
+
 ## 2019-10-24
 ### Added
 * Added boto3 and botocore to setup.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,20 @@
 # Changelog
 ## 2019-11-07
 ### Added
-* Query capabilities to address #29. This currently includes capabilites for:
-  - Action Table: (1) list of all actions in a service, (2) details on specific action
+* Query capabilities to address #29. This currently includes capabilities for:
+  - Action Table: 
+    - (1) list of all actions in a service
+    - (2) details on specific action
+    - (3) details on actions matching a service and access levels
     - Need to provide more granular queries for querying the access table before finalizing PR. Especially the one based on access levels, and available condition keys per action or ARN.
   - ARN Table: (1) list of all raw ARNs in a service, (2) details about a specific ARN type
   - Conditions Table: (1) list of all condition keys available to a service, (2) details about a specific condition key
 * Unit tests to accompany the query capabilities
+
 ### Changed
 * Fixed naming of a few unit tests to improve output in nosetests.
+* Fixed Condition Keys in actions table; it was previously set to the string 'None' instead of a null value. 
+* Fixed #33 by adding lines 214-222 to database.py
 
 ## 2019-10-24
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 2019-11-08
+### Added
+* Query capability to assist users in identifying actions to supply in future #16 feature
 ## 2019-11-07
 ### Added
 * Query capabilities to address #29. This currently includes capabilities for:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Changelog
 ## 2019-11-07
 ### Added
-* Query capabilities for conditions table.
-* Query capabilities for ARN table.
-* Query capabilities for action table. Needs enhancement.
+* Query capabilities to address #29. This currently includes capabilites for:
+  - Action Table: (1) list of all actions in a service, (2) details on specific action
+    - Need to provide more granular queries for querying the access table before finalizing PR. Especially the one based on access levels, and available condition keys per action or ARN.
+  - ARN Table: (1) list of all raw ARNs in a service, (2) details about a specific ARN type
+  - Conditions Table: (1) list of all condition keys available to a service, (2) details about a specific condition key
+* Unit tests to accompany the query capabilities
 ### Changed
 * Fixed naming of a few unit tests to improve output in nosetests.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## 2019-11-07
 ### Added
 * Query capabilities for conditions table.
+* Query capabilities for ARN table.
 ## 2019-10-24
 ### Added
 * Added boto3 and botocore to setup.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
     - Need to provide more granular queries for querying the access table before finalizing PR. Especially the one based on access levels, and available condition keys per action or ARN.
   - ARN Table: (1) list of all raw ARNs in a service, (2) details about a specific ARN type
   - Conditions Table: (1) list of all condition keys available to a service, (2) details about a specific condition key
+  - Specialized
+    - Query the actions table for actions within a service that support specific Condition keys
+    - Query the actions table for the same as above, but regardless of service
+* To finalize the query capabilities, just need to run it by Matty, make adjustments with Click Contexts, and squash commits.
+
 * Unit tests to accompany the query capabilities
 
 ### Changed

--- a/policy_sentry/bin/policy_sentry
+++ b/policy_sentry/bin/policy_sentry
@@ -20,6 +20,7 @@ policy_sentry.add_command(command.write_policy.write_policy)
 policy_sentry.add_command(command.write_policy_dir.write_policy_dir)
 policy_sentry.add_command(command.create_template.create_template)
 policy_sentry.add_command(command.download_policies.download_policies)
+policy_sentry.add_command(command.query.query)
 
 if __name__ == '__main__':
     policy_sentry()

--- a/policy_sentry/command/__init__.py
+++ b/policy_sentry/command/__init__.py
@@ -4,3 +4,4 @@ from policy_sentry.command import write_policy
 from policy_sentry.command import write_policy_dir
 from policy_sentry.command import create_template
 from policy_sentry.command import download_policies
+from policy_sentry.command import query

--- a/policy_sentry/command/query.py
+++ b/policy_sentry/command/query.py
@@ -1,0 +1,49 @@
+import click
+import pprint
+import json
+from policy_sentry.shared.query import query_condition_table, query_condition_table_by_name
+from policy_sentry.shared.database import connect_db
+from pathlib import Path
+
+HOME = str(Path.home())
+CONFIG_DIRECTORY = '/.policy_sentry/'
+DATABASE_FILE_NAME = 'aws.sqlite3'
+database_file_path = HOME + CONFIG_DIRECTORY + DATABASE_FILE_NAME
+
+@click.command(
+    short_help="Allow users to query the action, arn, and condition tables from command line."
+)
+@click.option(
+    '--table',
+    type=click.Choice(['action', 'arn', 'condition']),
+    required=True,
+    help='The table to query. Accepted values are action, arn, or condition.'
+)
+@click.option(
+    '--service',
+    type=str,
+    required=True,
+    help="Filter according to AWS service."
+)
+@click.option(
+    '--name',
+    type=str,
+    required=False,
+    help='Name of the action, arn type, or condition key. Optional.'
+)
+# TODO: Ask Matty about how to handle Click context
+#  so we can have different options for filtering based on which table the user selects
+def query(table, service, name):
+    """Allow users to query the action tables, arn tables, and condition keys tables from command line."""
+    print()
+    db_session = connect_db(database_file_path)
+    if table == 'condition':
+        if name is None:
+            condition_results = query_condition_table(db_session, service)
+            for item in condition_results:
+                print(item)
+        else:
+            output = query_condition_table_by_name(db_session, service, name)
+            print(json.dumps(output, indent=4))
+    else:
+        print("Did not select condition as the table. Please try again.")

--- a/policy_sentry/command/query.py
+++ b/policy_sentry/command/query.py
@@ -2,8 +2,10 @@ import click
 import pprint
 import json
 from policy_sentry.shared.query import query_condition_table, query_condition_table_by_name, query_arn_table, \
-    query_arn_table_by_name, query_action_table, query_action_table_by_name
+    query_arn_table_by_name, query_action_table, query_action_table_by_name, \
+    query_action_table_by_access_level, query_action_table_by_arn_type_and_access_level
 from policy_sentry.shared.database import connect_db
+from policy_sentry.shared.actions import transform_access_level_text
 from pathlib import Path
 
 HOME = str(Path.home())
@@ -32,9 +34,16 @@ database_file_path = HOME + CONFIG_DIRECTORY + DATABASE_FILE_NAME
     required=False,
     help='Name of the action, arn type, or condition key. Optional.'
 )
+@click.option(
+    '--access-level',
+    type=click.Choice(['read', 'write', 'list', 'tagging', 'permissions-management']),
+    required=False,
+    help='If action table is chosen, you can use this to filter according to CRUD levels. '
+         'Acceptable values are read, write, list, tagging, permissions-management'
+)
 # TODO: Ask Matty about how to handle Click context
 #  so we can have different options for filtering based on which table the user selects
-def query(table, service, name):
+def query(table, service, name, access_level):
     """Allow users to query the action tables, arn tables, and condition keys tables from command line."""
     db_session = connect_db(database_file_path)
     if table == 'condition':
@@ -54,12 +63,23 @@ def query(table, service, name):
             output = query_arn_table_by_name(db_session, service, name)
             print(json.dumps(output, indent=4))
     elif table == 'action':
-        if name is None:
+        if name is None and access_level is None:
             action_list = query_action_table(db_session, service)
+            print(f"ALL {service} actions:")
             for item in action_list:
                 print(item)
-        else:
-            output = query_action_table_by_name(db_session, service, name)
+        elif name is None and access_level:
+            level = transform_access_level_text(access_level)
+            output = query_action_table_by_access_level(db_session, service, level)
+            print(f"Service: {service}")
+            print(f"Access level: \"{level}\"")
+            print("Actions:")
             print(json.dumps(output, indent=4))
+        elif name and access_level is None:
+            output = query_action_table_by_name(db_session, service, name)
+            # print(f"Details on the IAM action \"{service}:{name}\":")
+            print(json.dumps(output, indent=4))
+        else:
+            print("Unknown error - no proper choices for action table query.")
     else:
         print("Table name not valid.")

--- a/policy_sentry/command/query.py
+++ b/policy_sentry/command/query.py
@@ -1,10 +1,10 @@
 import click
-import pprint
 import json
-from policy_sentry.shared.query import query_condition_table, query_condition_table_by_name, query_arn_table, \
-    query_arn_table_by_name, query_action_table, query_action_table_by_name, \
+from policy_sentry.shared.query import query_condition_table, query_condition_table_by_name, \
+    query_arn_table_for_raw_arns, query_arn_table_by_name, query_action_table, query_action_table_by_name, \
     query_action_table_by_access_level, query_action_table_by_arn_type_and_access_level, \
-    query_action_table_for_all_condition_key_matches, query_action_table_for_actions_supporting_wildcards_only
+    query_action_table_for_all_condition_key_matches, query_action_table_for_actions_supporting_wildcards_only, \
+    query_arn_table_for_arn_types
 from policy_sentry.shared.database import connect_db
 from policy_sentry.shared.actions import transform_access_level_text
 from pathlib import Path
@@ -57,33 +57,49 @@ database_file_path = HOME + CONFIG_DIRECTORY + DATABASE_FILE_NAME
     help='If action table is chosen, show the IAM actions that only support '
          'wildcard resources - i.e., cannot support ARNs in the resource block.'
 )
+@click.option(
+    '--list-arn-types',
+    is_flag=True,
+    required=False,
+    help='If ARN table is chosen, show the short names of ARN Types.'
+)
 # TODO: Ask Matty about how to handle Click context
 #  so we can have different options for filtering based on which table the user selects
-def query(table, service, name, access_level, condition, wildcard_only):
+def query(table, service, name, access_level, condition, wildcard_only, list_arn_types):
     """Allow users to query the action tables, arn tables, and condition keys tables from command line."""
     db_session = connect_db(database_file_path)
     if table == 'condition':
+        # Get a list of all condition keys available to the service
         if name is None:
             condition_results = query_condition_table(db_session, service)
             for item in condition_results:
                 print(item)
+        # Get details on the specific condition key
         else:
             output = query_condition_table_by_name(db_session, service, name)
             print(json.dumps(output, indent=4))
     elif table == 'arn':
-        if name is None:
-            raw_arns = query_arn_table(db_session, service)
+        # Get a list of all RAW ARN formats available through the service.
+        if name is None and list_arn_types is None:
+            raw_arns = query_arn_table_for_raw_arns(db_session, service)
             for item in raw_arns:
                 print(item)
+        # Get a list of all the ARN types per service, paired with the RAW ARNs
+        elif name is None and list_arn_types:
+            output = query_arn_table_for_arn_types(db_session, service)
+            print(json.dumps(output, indent=4))
+        # Get the raw ARN format for the `cloud9` service with the short name `environment`
         else:
             output = query_arn_table_by_name(db_session, service, name)
             print(json.dumps(output, indent=4))
     elif table == 'action':
+        # Get a list of all IAM Actions available to the service
         if name is None and access_level is None and condition is None and wildcard_only is None:
             action_list = query_action_table(db_session, service)
             print(f"ALL {service} actions:")
             for item in action_list:
                 print(item)
+        # Get a list of all IAM actions under the service that have the specified access level.
         elif name is None and access_level:
             level = transform_access_level_text(access_level)
             output = query_action_table_by_access_level(db_session, service, level)
@@ -91,17 +107,21 @@ def query(table, service, name, access_level, condition, wildcard_only):
             print(f"Access level: \"{level}\"")
             print("Actions:")
             print(json.dumps(output, indent=4))
+        # Get a list of all IAM actions under the service that support the specified condition key.
         elif condition:
-            print(f"IAM actions under {service} service that support wildcard resource values only:")
+            print(f"IAM actions under {service} service that support the {condition} condition only:")
             output = query_action_table_for_all_condition_key_matches(db_session, service, condition)
             print(json.dumps(output, indent=4))
+        # Get a list of IAM Actions under the service that only support resources = "*"
+        # (i.e., you cannot restrict it according to ARN)
         elif wildcard_only:
+            print(f"IAM actions under {service} service that support wildcard resource values only:")
             output = query_action_table_for_actions_supporting_wildcards_only(db_session, service)
             print(json.dumps(output, indent=4))
         elif name and access_level is None:
             output = query_action_table_by_name(db_session, service, name)
             print(json.dumps(output, indent=4))
         else:
-            print("Unknown error - no proper choices for action table query.")
+            print("Unknown error for query command - this error should not happen.")
     else:
         print("Table name not valid.")

--- a/policy_sentry/command/query.py
+++ b/policy_sentry/command/query.py
@@ -1,7 +1,8 @@
 import click
 import pprint
 import json
-from policy_sentry.shared.query import query_condition_table, query_condition_table_by_name, query_arn_table, query_arn_table_by_name
+from policy_sentry.shared.query import query_condition_table, query_condition_table_by_name, query_arn_table, \
+    query_arn_table_by_name, query_action_table
 from policy_sentry.shared.database import connect_db
 from pathlib import Path
 
@@ -52,4 +53,10 @@ def query(table, service, name):
         else:
             output = query_arn_table_by_name(db_session, service, name)
             print(json.dumps(output, indent=4))
-
+    elif table == 'action':
+        if name is None:
+            action_list = query_action_table(db_session, service)
+            for item in action_list:
+                print(item)
+    else:
+        print("Table name not valid.")

--- a/policy_sentry/command/query.py
+++ b/policy_sentry/command/query.py
@@ -2,7 +2,7 @@ import click
 import pprint
 import json
 from policy_sentry.shared.query import query_condition_table, query_condition_table_by_name, query_arn_table, \
-    query_arn_table_by_name, query_action_table
+    query_arn_table_by_name, query_action_table, query_action_table_by_name
 from policy_sentry.shared.database import connect_db
 from pathlib import Path
 
@@ -58,5 +58,8 @@ def query(table, service, name):
             action_list = query_action_table(db_session, service)
             for item in action_list:
                 print(item)
+        else:
+            output = query_action_table_by_name(db_session, service, name)
+            print(json.dumps(output, indent=4))
     else:
         print("Table name not valid.")

--- a/policy_sentry/command/query.py
+++ b/policy_sentry/command/query.py
@@ -35,7 +35,6 @@ database_file_path = HOME + CONFIG_DIRECTORY + DATABASE_FILE_NAME
 #  so we can have different options for filtering based on which table the user selects
 def query(table, service, name):
     """Allow users to query the action tables, arn tables, and condition keys tables from command line."""
-    print()
     db_session = connect_db(database_file_path)
     if table == 'condition':
         if name is None:
@@ -45,5 +44,5 @@ def query(table, service, name):
         else:
             output = query_condition_table_by_name(db_session, service, name)
             print(json.dumps(output, indent=4))
-    else:
-        print("Did not select condition as the table. Please try again.")
+
+

--- a/policy_sentry/command/query.py
+++ b/policy_sentry/command/query.py
@@ -1,7 +1,7 @@
 import click
 import pprint
 import json
-from policy_sentry.shared.query import query_condition_table, query_condition_table_by_name
+from policy_sentry.shared.query import query_condition_table, query_condition_table_by_name, query_arn_table, query_arn_table_by_name
 from policy_sentry.shared.database import connect_db
 from pathlib import Path
 
@@ -44,5 +44,12 @@ def query(table, service, name):
         else:
             output = query_condition_table_by_name(db_session, service, name)
             print(json.dumps(output, indent=4))
-
+    elif table == 'arn':
+        if name is None:
+            raw_arns = query_arn_table(db_session, service)
+            for item in raw_arns:
+                print(item)
+        else:
+            output = query_arn_table_by_name(db_session, service, name)
+            print(json.dumps(output, indent=4))
 

--- a/policy_sentry/shared/actions.py
+++ b/policy_sentry/shared/actions.py
@@ -86,6 +86,17 @@ def get_action_name_from_action(action):
     return str.lower(action_name)
 
 
+def get_full_action_name(service, action_name):
+    """
+    Gets the proper formatting for an action - the service, plus colon, plus action name.
+    :param service: service name, like s3
+    :param action_name: action name, like createbucket
+    :return: the resulting string
+    """
+    action = service + ':' + action_name
+    return action
+
+
 def get_dependent_actions(db_session, actions_list):
     """
     Given a list of IAM Actions, query the database to determine if the action has dependent actions in the

--- a/policy_sentry/shared/actions.py
+++ b/policy_sentry/shared/actions.py
@@ -38,24 +38,12 @@ def get_actions_by_access_level(db_session, actions_list, access_level):
         service, action_name = action.split(':')
         action = str.lower(action)
         first_result = None  # Just to appease nosetests
-        if access_level == "read":
-            level = "Read"
-        elif access_level == "write":
-            level = "Write"
-        elif access_level == "list":
-            level = "List"
-        elif access_level == "tagging":
-            level = "Tagging"
-        elif access_level == "permissions-management":
-            level = "Permissions management"
-        else:
-            print("Error: Please specify the correct access level.")
-            sys.exit(0)
-        query_actions_access_level = db_session.query(ActionTable).filter(
-            and_(ActionTable.service.like(service),
-                 ActionTable.name.like(str.lower(action_name)),
-                ActionTable.access_level.like(level)
-                 ))
+        level = transform_access_level_text(access_level)
+        query_actions_access_level = db_session.query(ActionTable).filter(and_(
+            ActionTable.service.like(service),
+            ActionTable.name.like(str.lower(action_name)),
+            ActionTable.access_level.like(level)
+        ))
 
         first_result = query_actions_access_level.first()
         if first_result is None:
@@ -64,6 +52,25 @@ def get_actions_by_access_level(db_session, actions_list, access_level):
             # Just take the first result
             new_actions_list.append(action)
     return new_actions_list
+
+
+def transform_access_level_text(access_level):
+    """This takes the Click choices for access levels, like permissions-management, and
+    returns the text format matching that access level, but in the format that SQLite database expects"""
+    if access_level == "read":
+        level = "Read"
+    elif access_level == "write":
+        level = "Write"
+    elif access_level == "list":
+        level = "List"
+    elif access_level == "tagging":
+        level = "Tagging"
+    elif access_level == "permissions-management":
+        level = "Permissions management"
+    else:
+        print("Error: Please specify the correct access level.")
+        sys.exit(0)
+    return level
 
 
 def get_service_from_action(action):

--- a/policy_sentry/shared/conditions.py
+++ b/policy_sentry/shared/conditions.py
@@ -1,3 +1,4 @@
+# Just some text transformation functions related to our conditions-related workarounds
 def get_service_from_condition_key(condition_key):
     elements = condition_key.split(':', 2)
     return elements[0]
@@ -9,5 +10,4 @@ def get_comma_separated_condition_keys(condition_keys):
     :return: result: String containing multiple condition keys, comma-separated
     """
     result = condition_keys.replace('  ', ',')  # replace the double spaces with a comma
-
     return result

--- a/policy_sentry/shared/database.py
+++ b/policy_sentry/shared/database.py
@@ -49,9 +49,10 @@ class ArnTable(Base):
     account = Column(String(50))
     resource = Column(String(50))
     resource_path = Column(String(50))
+    condition_keys = Column(String(50))
 
     def __repr__(self):
-        return "<Arn(resource_type_name='%s', raw_arn='%s', arn='%s', partition='%s', service='%s', region='%s', account='%s', resource='%s', resource_path='%s')>" % (
+        return "<Arn(resource_type_name='%s', raw_arn='%s', arn='%s', partition='%s', service='%s', region='%s', account='%s', resource='%s', resource_path='%s', condition_keys='%s')>" % (
             self.resource_type_name,
             self.raw_arn,
             self.arn,
@@ -60,7 +61,8 @@ class ArnTable(Base):
             self.region,
             self.account,
             self.resource,
-            self.resource_path
+            self.resource_path,
+            self.condition_keys
         )
 
 
@@ -210,8 +212,7 @@ def build_action_table(db_session, service, access_level_overrides_file):
                         access_level = table['data'][i][2]
                     # Condition keys #####
                     if table['data'][i][4] is None:
-                        # In order to avoid errors with NULL Database entries, set to 'None'
-                        condition_keys = 'None'
+                        condition_keys = None
                     # If there are multiple condition keys, make them comma separated
                     # Otherwise, if we ingest them as-is, it will show up as two spaces
                     elif '  ' in table['data'][i][4]:
@@ -260,11 +261,22 @@ def build_arn_table(db_session, service):
             if 'Resource Types' in table_data and 'ARN' in table_data:
                 temp = table['data'][1::]
                 for i in range(len(table['data'])):
+                    # Handle resource ARN path
                     if get_resource_path_from_arn(table['data'][i][1]):
                         resource_path = get_resource_path_from_arn(
                             table['data'][i][1])
                     else:
                         resource_path = ''
+                    # Handle condition keys
+                    if table['data'][i][2] is None:
+                        condition_keys = None
+                    # If there are multiple condition keys, make them comma separated
+                    # Otherwise, if we ingest them as-is, it will show up as two spaces
+                    elif '  ' in table['data'][i][2]:
+                        condition_keys = get_comma_separated_condition_keys(
+                            table['data'][i][2])
+                    else:
+                        condition_keys = table['data'][i][2]
                     db_session.add(ArnTable(
                         resource_type_name=table['data'][i][0],
                         raw_arn=str(table['data'][i][1]).replace(
@@ -276,7 +288,8 @@ def build_arn_table(db_session, service):
                         region=get_region_from_arn(table['data'][i][1]),
                         account=get_account_from_arn(table['data'][i][1]),
                         resource=get_resource_from_arn(table['data'][i][1]),
-                        resource_path=resource_path
+                        resource_path=resource_path,
+                        condition_keys=condition_keys
                         # resource_path=get_resource_path_from_arn(table['data'][i][1])
                     ))
                     db_session.commit()

--- a/policy_sentry/shared/policy.py
+++ b/policy_sentry/shared/policy.py
@@ -102,7 +102,7 @@ class ArnActionGroup:
         #     print("Yaml file is missing this block: " + e.args[0])
         #     sys.exit()
         except IndexError:
-            print("IndexError: list index out of range. This is likely due to an ARN in your list equaling ''."
+            print("IndexError: list index out of range. This is likely due to an ARN in your list equaling ''. "
                   "Please evaluate your YML file and try again.")
             sys.exit()
 

--- a/policy_sentry/shared/query.py
+++ b/policy_sentry/shared/query.py
@@ -71,8 +71,14 @@ def query_action_table_by_name(db_session, service, name):
 
     for row in rows:
         action = row.service + ':' + row.name
-        # if row.condition_keys: # TODO: Split the condition keys based on commas.
-        # if row.dependent_actions: # TODO: Split the dependent actions based on commas.
+        if row.condition_keys:
+            condition_keys = row.condition_keys.split(",")
+        else:
+            condition_keys = None
+        if row.dependent_actions:
+            dependent_actions = row.dependent_actions.split(",")
+        else:
+            dependent_actions = None
         # if row.dependent_actions is None:
         #     # We have to do this otherwise the output will officially be "dependent_actions": null
         #     dependent_actions = None
@@ -83,8 +89,8 @@ def query_action_table_by_name(db_session, service, name):
             "description": row.description,
             "access_level": row.access_level,
             "resource_arn_format": row.resource_arn_format,
-            "condition_keys": row.condition_keys,
-            "dependent_actions": row.dependent_actions
+            "condition_keys": condition_keys,
+            "dependent_actions": dependent_actions
         }
         results.append(temp_dict)
 
@@ -105,14 +111,11 @@ def query_action_table_by_access_level(db_session, service, access_level):
         action = get_full_action_name(row.service, row.name)
         if action not in actions_list:
             actions_list.append(action)
-
-    # actions_list_with_requested_access_level_only = get_actions_by_access_level(db_session, actions_list, access_level)
     return actions_list
 
 
 def query_action_table_by_arn_type_and_access_level(db_session, service, resource_type_name, access_level):
     """Get a list of actions in a service under different access levels, specific to an ARN format."""
-    # Thought: Should I use a function to filter for the access level beforehand?
     actions_list = []
     rows = db_session.query(ActionTable).filter(and_(
         ActionTable.service.ilike(service),

--- a/policy_sentry/shared/query.py
+++ b/policy_sentry/shared/query.py
@@ -98,6 +98,18 @@ def query_action_table_by_name(db_session, service, name):
     return action_table_results
 
 
+def query_action_table_for_actions_supporting_wildcards_only(db_session, service):
+    actions_list = []
+    rows = db_session.query(ActionTable.service, ActionTable.name).filter(and_(
+        ActionTable.service.ilike(service),
+        ActionTable.resource_arn_format.like("*"),
+        ActionTable.name.notin_(db_session.query(ActionTable.name).filter(ActionTable.resource_arn_format.notlike('*')))
+    ))
+    for row in rows:
+        actions_list.append(get_full_action_name(row.service, row.name))
+    return actions_list
+
+
 def query_action_table_by_access_level(db_session, service, access_level):
     """Get a list of actions in a service under different access levels."""
     actions_list = []

--- a/policy_sentry/shared/query.py
+++ b/policy_sentry/shared/query.py
@@ -58,3 +58,37 @@ def query_action_table(db_session, service):
         if action not in results:
             results.append(action)
     return results
+
+
+def query_action_table_by_name(db_session, service, name):
+    """Get details about an IAM Action in JSON format."""
+    rows = db_session.query(ActionTable).filter(and_(ActionTable.service.ilike(service), ActionTable.name.ilike(name)))
+    # TODO: Before submitting #29, Throw an error if it doesn't match. This is likely because the user is likely to
+    #  provide `service:action_name` as the name at first, and we want to direct them to just use the action name.
+
+    # TODO: Before submitting #29, Handle cases where the actions match multiple times - for example,
+    #  there are multiple entries for ram:TagResource due to the two different ARN formats.
+    action_table_results = {}
+    results = []
+
+    for row in rows:
+        action = row.service + ':' + row.name
+        # if row.condition_keys: # TODO: Split the condition keys based on commas.
+        # if row.dependent_actions: # TODO: Split the dependent actions based on commas.
+        # if row.dependent_actions is None:
+        #     # We have to do this otherwise the output will officially be "dependent_actions": null
+        #     dependent_actions = None
+        # else:
+        #     dependent_actions = row.dependent_actions
+        temp_dict = {
+            "action": action,
+            "description": row.description,
+            "access_level": row.access_level,
+            "resource_arn_format": row.resource_arn_format,
+            "condition_keys": row.condition_keys,
+            "dependent_actions": row.dependent_actions
+        }
+        results.append(temp_dict)
+
+    action_table_results[service] = results
+    return action_table_results

--- a/policy_sentry/shared/query.py
+++ b/policy_sentry/shared/query.py
@@ -1,0 +1,31 @@
+from sqlalchemy import and_
+from policy_sentry.shared.database import ActionTable, ArnTable, ConditionTable
+
+# https://stackoverflow.com/questions/34538457/alternative-to-stored-procedures-in-sqlite3
+# https://sebastianraschka.com/Articles/2014_sqlite_in_python_tutorial.html#retrieving-column-names
+# def query_action_table(service):
+
+
+# Per service
+def query_condition_table(db_session, service):
+    """Get a list of available conditions per AWS service"""
+    results = set()
+    rows = db_session.query(ConditionTable.condition_key_name, ConditionTable.condition_value_type,
+                            ConditionTable.description).filter(ConditionTable.service.like(service))
+    for row in rows:
+        results.add(str(row.condition_key_name))
+    return results
+
+
+# Per condition key name
+def query_condition_table_by_name(db_session, service, condition_key_name):
+    """Get details about a specific condition key in JSON format"""
+    rows = db_session.query(ConditionTable.condition_key_name, ConditionTable.condition_value_type,
+                            ConditionTable.description).filter(and_(ConditionTable.condition_key_name.like(condition_key_name), ConditionTable.service.like(service)))
+    result = rows.first()
+    output = {
+        'name': result.condition_key_name,
+        'description': result.description,
+        'condition_value_type': result.condition_value_type
+    }
+    return output

--- a/policy_sentry/shared/query.py
+++ b/policy_sentry/shared/query.py
@@ -29,3 +29,26 @@ def query_condition_table_by_name(db_session, service, condition_key_name):
         'condition_value_type': result.condition_value_type
     }
     return output
+
+
+def query_arn_table(db_session, service):
+    """Get a list of available ARNs per AWS service"""
+    results = []
+    rows = db_session.query(ArnTable.raw_arn).filter(ArnTable.service.like(service))
+    for row in rows:
+        results.append(str(row.raw_arn))
+    return results
+
+
+def query_arn_table_by_name(db_session, service, name):
+    """Get details about a resource ARN type name in JSON format."""
+    rows = db_session.query(ArnTable.resource_type_name, ArnTable.raw_arn).filter(
+        ArnTable.resource_type_name.like(name), ArnTable.service.like(service))
+    result = rows.first()
+    output = {
+        'resource_type_name': result.resource_type_name,
+        'raw_arn': result.raw_arn
+        # TODO: After #33 is fixed, add the items from the condition keys column here.
+    }
+    return output
+

--- a/policy_sentry/shared/query.py
+++ b/policy_sentry/shared/query.py
@@ -1,10 +1,6 @@
 from sqlalchemy import and_
 from policy_sentry.shared.database import ActionTable, ArnTable, ConditionTable
 
-# https://stackoverflow.com/questions/34538457/alternative-to-stored-procedures-in-sqlite3
-# https://sebastianraschka.com/Articles/2014_sqlite_in_python_tutorial.html#retrieving-column-names
-# def query_action_table(service):
-
 
 # Per service
 def query_condition_table(db_session, service):
@@ -52,3 +48,13 @@ def query_arn_table_by_name(db_session, service, name):
     }
     return output
 
+
+def query_action_table(db_session, service):
+    """Get a list of available actions per AWS service"""
+    results = []
+    rows = db_session.query(ActionTable.service, ActionTable.name).filter(ActionTable.service.like(service))
+    for row in rows:
+        action = row.service + ':' + row.name
+        if action not in results:
+            results.append(action)
+    return results

--- a/policy_sentry/shared/query.py
+++ b/policy_sentry/shared/query.py
@@ -9,11 +9,11 @@ from policy_sentry.shared.database import ActionTable, ArnTable, ConditionTable
 # Per service
 def query_condition_table(db_session, service):
     """Get a list of available conditions per AWS service"""
-    results = set()
+    results = []
     rows = db_session.query(ConditionTable.condition_key_name, ConditionTable.condition_value_type,
                             ConditionTable.description).filter(ConditionTable.service.like(service))
     for row in rows:
-        results.add(str(row.condition_key_name))
+        results.append(str(row.condition_key_name))
     return results
 
 

--- a/policy_sentry/shared/query.py
+++ b/policy_sentry/shared/query.py
@@ -28,13 +28,21 @@ def query_condition_table_by_name(db_session, service, condition_key_name):
     return output
 
 
-def query_arn_table(db_session, service):
-    """Get a list of available ARNs per AWS service"""
+def query_arn_table_for_raw_arns(db_session, service):
+    """Get a list of available raw ARNs per AWS service"""
     results = []
     rows = db_session.query(ArnTable.raw_arn).filter(ArnTable.service.like(service))
     for row in rows:
         results.append(str(row.raw_arn))
-    # TODO: Instead of JUST the raw ARN, return a pairing of the resource type name and the raw ARN itself.
+    return results
+
+
+def query_arn_table_for_arn_types(db_session, service):
+    """Get a list of available ARN short names per AWS service"""
+    results = {}
+    rows = db_session.query(ArnTable.resource_type_name, ArnTable.raw_arn).filter(ArnTable.service.like(service))
+    for row in rows:
+        results[row.resource_type_name] = row.raw_arn
     return results
 
 

--- a/test/test_access_level_overrides.py
+++ b/test/test_access_level_overrides.py
@@ -4,14 +4,14 @@ from policy_sentry.shared.config import get_action_access_level_overrides_from_y
 
 class AccessLevelOverride(unittest.TestCase):
     def test_passing_overall_iam_action_override(self):
-        """Tests iam:CreateAccessKey (in overrides file as Permissions management, but in the AWS docs as Write)"""
+        """test_passing_overall_iam_action_override: Tests iam:CreateAccessKey (in overrides file as Permissions management, but in the AWS docs as Write)"""
         desired_result = "Permissions management"
         action_overrides = get_action_access_level_overrides_from_yml("iam")
         result = determine_access_level_override("iam", "CreateAccessKey", "Write", action_overrides)
         self.assertEqual(result, desired_result)
 
     def test_overrides_yml_config(self):
-        """Tests the format of the overrides yml file for the RAM service"""
+        """test_overrides_yml_config: Tests the format of the overrides yml file for the RAM service"""
         desired_result = {
             'Permissions management': [
                 'acceptresourceshareinvitation',

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -1,0 +1,36 @@
+import unittest
+from pathlib import Path
+from policy_sentry.shared.database import connect_db
+from policy_sentry.shared.query import query_condition_table_by_name, query_condition_table
+
+HOME = str(Path.home())
+CONFIG_DIRECTORY = '/.policy_sentry/'
+DATABASE_FILE_NAME = 'aws.sqlite3'
+database_file_path = HOME + CONFIG_DIRECTORY + DATABASE_FILE_NAME
+db_session = connect_db(database_file_path)
+
+
+class QueryTestCase(unittest.TestCase):
+    def test_query_condition_table(self):
+        """Tests function that grabs a list of condition keys per service."""
+        desired_output = [
+            'cloud9:EnvironmentId',
+            'cloud9:EnvironmentName',
+            'cloud9:InstanceType',
+            'cloud9:Permissions',
+            'cloud9:SubnetId',
+            'cloud9:UserArn'
+        ]
+        output = query_condition_table(db_session, "cloud9")
+        self.assertEquals(desired_output, output)
+
+    def test_query_condition_table_by_name(self):
+        """Tests function that grabs details about a specific condition key"""
+        desired_output = {
+            "name": "cloud9:Permissions",
+            "description": "Filters access by the type of AWS Cloud9 permissions",
+            "condition_value_type": "string"
+        }
+        output = query_condition_table_by_name(db_session, "cloud9", "cloud9:Permissions")
+        self.assertEquals(desired_output, output)
+

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -96,7 +96,8 @@ class QueryTestCase(unittest.TestCase):
         self.assertDictEqual(desired_output, output)
 
     def test_query_action_table_by_access_level(self):
-        """test_query_action_table_by_access_level: Tests function that gets a list of actions in a service under different access levels."""
+        """test_query_action_table_by_access_level: Tests function that gets a list of actions in a
+        service under different access levels."""
         # desired_output = ""
         desired_output = ['ram:acceptresourceshareinvitation', 'ram:associateresourceshare', 'ram:createresourceshare',
                         'ram:deleteresourceshare', 'ram:disassociateresourceshare',
@@ -107,9 +108,11 @@ class QueryTestCase(unittest.TestCase):
         self.assertListEqual(desired_output, output)
 
     def test_query_action_table_by_arn_type_and_access_level(self):
-        """test_query_action_table_by_arn_type_and_access_level: Tests a function that gets a list of actions in a service under different access levels, specific to an ARN format."""
+        """test_query_action_table_by_arn_type_and_access_level: Tests a function that gets a list of
+        actions in a service under different access levels, specific to an ARN format."""
         desired_output = ""
-        desired_output = ['ram:associateresourceshare', 'ram:createresourceshare', 'ram:deleteresourceshare', 'ram:disassociateresourceshare', 'ram:updateresourceshare']
+        desired_output = ['ram:associateresourceshare', 'ram:createresourceshare', 'ram:deleteresourceshare',
+                          'ram:disassociateresourceshare', 'ram:updateresourceshare']
         output = query_action_table_by_arn_type_and_access_level(db_session, "ram", "resource-share",
                                                                  "Permissions management")
         print(output)

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -2,7 +2,7 @@ import unittest
 from pathlib import Path
 from policy_sentry.shared.database import connect_db
 from policy_sentry.shared.query import query_condition_table_by_name, query_condition_table, query_arn_table, \
-    query_arn_table_by_name, query_action_table
+    query_arn_table_by_name, query_action_table, query_action_table_by_name
 
 HOME = str(Path.home())
 CONFIG_DIRECTORY = '/.policy_sentry/'
@@ -68,3 +68,28 @@ class QueryTestCase(unittest.TestCase):
                         'ram:untagresource', 'ram:updateresourceshare']
         output = query_action_table(db_session, "ram")
         self.assertListEqual(desired_output, output)
+
+    def test_query_action_table_by_name(self):
+        """test_query_action_table_by_name: Tests function that gets details on a specific IAM Action."""
+        desired_output = {
+            "ram": [
+                {
+                    "action": "ram:createresourceshare",
+                    "description": "Create resource share with provided resource(s) and/or principal(s)",
+                    "access_level": "Permissions management",
+                    "resource_arn_format": "arn:aws:ram:${Region}:${Account}:resource-share/${ResourcePath}",
+                    "condition_keys": "ram:RequestedResourceType,ram:ResourceArn,ram:AllowsExternalPrincipals",
+                    "dependent_actions": None
+                },
+                {
+                    "action": "ram:createresourceshare",
+                    "description": "Create resource share with provided resource(s) and/or principal(s)",
+                    "access_level": "Permissions management",
+                    "resource_arn_format": "*",
+                    "condition_keys": "aws:RequestTag/${TagKey},aws:TagKeys",
+                    "dependent_actions": None
+                }
+            ]
+        }
+        output = query_action_table_by_name(db_session, 'ram', 'createresourceshare')
+        self.assertDictEqual(desired_output, output)

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -3,7 +3,8 @@ from pathlib import Path
 from policy_sentry.shared.database import connect_db
 from policy_sentry.shared.query import query_condition_table_by_name, query_condition_table, query_arn_table, \
     query_arn_table_by_name, query_action_table, query_action_table_by_name, query_action_table_by_access_level, \
-    query_action_table_by_arn_type_and_access_level, query_action_table_for_all_condition_key_matches
+    query_action_table_by_arn_type_and_access_level, query_action_table_for_all_condition_key_matches, \
+    query_action_table_for_actions_supporting_wildcards_only
 
 HOME = str(Path.home())
 CONFIG_DIRECTORY = '/.policy_sentry/'
@@ -147,3 +148,16 @@ class QueryTestCase(unittest.TestCase):
         self.maxDiff = None
         print(output)
         self.assertListEqual(desired_list, output)
+
+    def test_query_action_table_for_actions_supporting_wildcards_only(self):
+        """test_query_action_table_for_actions_supporting_wildcards_only: Tests function that shows all
+        actions that support * resources only."""
+        desired_output = [
+            "secretsmanager:createsecret",
+            "secretsmanager:getrandompassword",
+            "secretsmanager:listsecrets"
+        ]
+        output = query_action_table_for_actions_supporting_wildcards_only(db_session, "secretsmanager")
+        self.maxDiff = None
+        print(output)
+        self.assertListEqual(desired_output, output)

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -2,7 +2,7 @@ import unittest
 from pathlib import Path
 from policy_sentry.shared.database import connect_db
 from policy_sentry.shared.query import query_condition_table_by_name, query_condition_table, query_arn_table, \
-    query_arn_table_by_name
+    query_arn_table_by_name, query_action_table
 
 HOME = str(Path.home())
 CONFIG_DIRECTORY = '/.policy_sentry/'
@@ -13,7 +13,7 @@ db_session = connect_db(database_file_path)
 
 class QueryTestCase(unittest.TestCase):
     def test_query_condition_table(self):
-        """Tests function that grabs a list of condition keys per service."""
+        """test_query_condition_table: Tests function that grabs a list of condition keys per service."""
         desired_output = [
             'cloud9:EnvironmentId',
             'cloud9:EnvironmentName',
@@ -26,7 +26,7 @@ class QueryTestCase(unittest.TestCase):
         self.assertEquals(desired_output, output)
 
     def test_query_condition_table_by_name(self):
-        """Tests function that grabs details about a specific condition key"""
+        """test_query_condition_table_by_name: Tests function that grabs details about a specific condition key"""
         desired_output = {
             "name": "cloud9:Permissions",
             "description": "Filters access by the type of AWS Cloud9 permissions",
@@ -36,7 +36,7 @@ class QueryTestCase(unittest.TestCase):
         self.assertEquals(desired_output, output)
 
     def test_query_arn_table(self):
-        """Tests function that grabs a list of raw ARNs per service"""
+        """test_query_arn_table: Tests function that grabs a list of raw ARNs per service"""
         desired_output = [
             'arn:aws:ssm:${Region}:${Account}:document/${DocumentName}',
             'arn:aws:ssm:${Region}:${Account}:maintenancewindow/${ResourceId}',
@@ -50,7 +50,7 @@ class QueryTestCase(unittest.TestCase):
         self.assertListEqual(desired_output, output)
 
     def test_query_arn_table_by_name(self):
-        """Tests function that grabs details about a specific ARN name"""
+        """test_query_arn_table_by_name: Tests function that grabs details about a specific ARN name"""
         desired_output = {
             "resource_type_name": "environment",
             "raw_arn": "arn:aws:cloud9:${Region}:${Account}:environment:${ResourceId}"
@@ -58,4 +58,13 @@ class QueryTestCase(unittest.TestCase):
         output = query_arn_table_by_name(db_session, "cloud9", "environment")
         self.assertEquals(desired_output, output)
 
-
+    def test_query_action_table(self):
+        """test_query_action_table: Tests function that gets a list of actions per AWS service."""
+        desired_output = ['ram:acceptresourceshareinvitation', 'ram:associateresourceshare', 'ram:createresourceshare',
+                        'ram:deleteresourceshare', 'ram:disassociateresourceshare',
+                        'ram:enablesharingwithawsorganization', 'ram:getresourcepolicies',
+                        'ram:getresourceshareassociations', 'ram:getresourceshareinvitations', 'ram:getresourceshares',
+                        'ram:listpendinginvitationresources', 'ram:rejectresourceshareinvitation', 'ram:tagresource',
+                        'ram:untagresource', 'ram:updateresourceshare']
+        output = query_action_table(db_session, "ram")
+        self.assertListEqual(desired_output, output)

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from policy_sentry.shared.database import connect_db
 from policy_sentry.shared.query import query_condition_table_by_name, query_condition_table, query_arn_table, \
     query_arn_table_by_name, query_action_table, query_action_table_by_name, query_action_table_by_access_level, \
-    query_action_table_by_arn_type_and_access_level
+    query_action_table_by_arn_type_and_access_level, query_action_table_for_all_condition_key_matches
 
 HOME = str(Path.home())
 CONFIG_DIRECTORY = '/.policy_sentry/'
@@ -54,7 +54,8 @@ class QueryTestCase(unittest.TestCase):
         """test_query_arn_table_by_name: Tests function that grabs details about a specific ARN name"""
         desired_output = {
             "resource_type_name": "environment",
-            "raw_arn": "arn:aws:cloud9:${Region}:${Account}:environment:${ResourceId}"
+            "raw_arn": "arn:aws:cloud9:${Region}:${Account}:environment:${ResourceId}",
+            "condition_keys": None
         }
         output = query_arn_table_by_name(db_session, "cloud9", "environment")
         self.assertEquals(desired_output, output)
@@ -125,3 +126,24 @@ class QueryTestCase(unittest.TestCase):
         print(output)
         self.maxDiff = None
         self.assertListEqual(desired_output, output)
+
+    def test_query_action_table_for_service_specific_condition_key_matches(self):
+        """test_query_action_table_for_all_condition_key_matches: Tests a function that gathers all instances in
+        the action tables where the condition key exists."""
+        desired_output = ['ses:sendbulktemplatedemail', 'ses:sendcustomverificationemail', 'ses:sendemail',
+                          'ses:sendrawemail', 'ses:sendtemplatedemail']
+        output = query_action_table_for_all_condition_key_matches(db_session, "ses", "ses:FeedbackAddress")
+        print(output)
+        self.maxDiff = None
+        self.assertListEqual(desired_output, output)
+
+    def test_query_action_table_for_all_condition_key_matches(self):
+        """test_query_action_table_for_all_condition_key_matches: Tests a function that creates a list of all IAM
+        actions that support the supplied condition key."""
+        # condition_key = "aws:RequestTag"
+        desired_list = ['appstream:associatefleet', 'appstream:batchassociateuserstack', 'appstream:batchdisassociateuserstack', 'appstream:copyimage', 'appstream:createimagebuilderstreamingurl', 'appstream:createstreamingurl', 'appstream:deletefleet', 'appstream:deleteimage', 'appstream:deleteimagebuilder', 'appstream:deleteimagepermissions', 'appstream:deletestack', 'appstream:disassociatefleet', 'appstream:startfleet', 'appstream:startimagebuilder', 'appstream:stopfleet', 'appstream:stopimagebuilder', 'appstream:tagresource', 'appstream:updatefleet', 'appstream:updateimagepermissions', 'appstream:updatestack', 'appsync:deletegraphqlapi', 'appsync:getgraphqlapi', 'appsync:listtagsforresource', 'appsync:tagresource', 'appsync:updategraphqlapi', 'codecommit:tagresource', 'cognito-identity:createidentitypool', 'cognito-identity:listtagsforresource', 'cognito-identity:tagresource', 'cognito-identity:untagresource', 'cognito-idp:createuserpool', 'cognito-idp:listtagsforresource', 'cognito-idp:tagresource', 'cognito-idp:untagresource', 'cognito-idp:updateuserpool', 'dms:describereplicationinstancetasklogs', 'mobiletargeting:createapp', 'mobiletargeting:createcampaign', 'mobiletargeting:createsegment', 'mobiletargeting:deletecampaign', 'mobiletargeting:deletesegment', 'mobiletargeting:getapp', 'mobiletargeting:getapps', 'mobiletargeting:getcampaign', 'mobiletargeting:getcampaignversion', 'mobiletargeting:getcampaignversions', 'mobiletargeting:getcampaigns', 'mobiletargeting:getsegment', 'mobiletargeting:getsegmentversion', 'mobiletargeting:getsegmentversions', 'mobiletargeting:getsegments', 'mobiletargeting:listtagsforresource', 'mobiletargeting:tagresource', 'mobiletargeting:untagresource', 'mobiletargeting:updatecampaign', 'mobiletargeting:updatesegment']
+        stuff = "aws:ResourceTag/${TagKey}"
+        output = query_action_table_for_all_condition_key_matches(db_session, service=None, condition_key=stuff)
+        self.maxDiff = None
+        print(output)
+        self.assertListEqual(desired_list, output)

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -73,26 +73,34 @@ class QueryTestCase(unittest.TestCase):
     def test_query_action_table_by_name(self):
         """test_query_action_table_by_name: Tests function that gets details on a specific IAM Action."""
         desired_output = {
-            "ram": [
+            'ram': [
                 {
-                    "action": "ram:createresourceshare",
-                    "description": "Create resource share with provided resource(s) and/or principal(s)",
-                    "access_level": "Permissions management",
-                    "resource_arn_format": "arn:aws:ram:${Region}:${Account}:resource-share/${ResourcePath}",
-                    "condition_keys": "ram:RequestedResourceType,ram:ResourceArn,ram:AllowsExternalPrincipals",
-                    "dependent_actions": None
+                    'action': 'ram:createresourceshare',
+                    'description': 'Create resource share with provided resource(s) and/or principal(s)',
+                    'access_level': 'Permissions management',
+                    'resource_arn_format': 'arn:aws:ram:${Region}:${Account}:resource-share/${ResourcePath}',
+                    'condition_keys': [
+                        'ram:RequestedResourceType',
+                        'ram:ResourceArn',
+                        'ram:AllowsExternalPrincipals'
+                    ],
+                    'dependent_actions': None
                 },
                 {
-                    "action": "ram:createresourceshare",
-                    "description": "Create resource share with provided resource(s) and/or principal(s)",
-                    "access_level": "Permissions management",
-                    "resource_arn_format": "*",
-                    "condition_keys": "aws:RequestTag/${TagKey},aws:TagKeys",
-                    "dependent_actions": None
+                    'action': 'ram:createresourceshare',
+                    'description': 'Create resource share with provided resource(s) and/or principal(s)',
+                    'access_level': 'Permissions management',
+                    'resource_arn_format': '*',
+                    'condition_keys': [
+                        'aws:RequestTag/${TagKey}',
+                        'aws:TagKeys'
+                    ],
+                    'dependent_actions': None
                 }
             ]
         }
         output = query_action_table_by_name(db_session, 'ram', 'createresourceshare')
+        self.maxDiff = None
         self.assertDictEqual(desired_output, output)
 
     def test_query_action_table_by_access_level(self):
@@ -104,6 +112,7 @@ class QueryTestCase(unittest.TestCase):
                         'ram:updateresourceshare']
         output = query_action_table_by_access_level(db_session, "ram", "Permissions management")
         print(output)
+        self.maxDiff = None
         self.assertListEqual(desired_output, output)
 
     def test_query_action_table_by_arn_type_and_access_level(self):
@@ -114,4 +123,5 @@ class QueryTestCase(unittest.TestCase):
         output = query_action_table_by_arn_type_and_access_level(db_session, "ram", "resource-share",
                                                                  "Permissions management")
         print(output)
+        self.maxDiff = None
         self.assertListEqual(desired_output, output)

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -2,7 +2,8 @@ import unittest
 from pathlib import Path
 from policy_sentry.shared.database import connect_db
 from policy_sentry.shared.query import query_condition_table_by_name, query_condition_table, query_arn_table, \
-    query_arn_table_by_name, query_action_table, query_action_table_by_name
+    query_arn_table_by_name, query_action_table, query_action_table_by_name, query_action_table_by_access_level, \
+    query_action_table_by_arn_type_and_access_level
 
 HOME = str(Path.home())
 CONFIG_DIRECTORY = '/.policy_sentry/'
@@ -93,3 +94,23 @@ class QueryTestCase(unittest.TestCase):
         }
         output = query_action_table_by_name(db_session, 'ram', 'createresourceshare')
         self.assertDictEqual(desired_output, output)
+
+    def test_query_action_table_by_access_level(self):
+        """test_query_action_table_by_access_level: Tests function that gets a list of actions in a service under different access levels."""
+        # desired_output = ""
+        desired_output = ['ram:acceptresourceshareinvitation', 'ram:associateresourceshare', 'ram:createresourceshare',
+                        'ram:deleteresourceshare', 'ram:disassociateresourceshare',
+                        'ram:enablesharingwithawsorganization', 'ram:rejectresourceshareinvitation',
+                        'ram:updateresourceshare']
+        output = query_action_table_by_access_level(db_session, "ram", "Permissions management")
+        print(output)
+        self.assertListEqual(desired_output, output)
+
+    def test_query_action_table_by_arn_type_and_access_level(self):
+        """test_query_action_table_by_arn_type_and_access_level: Tests a function that gets a list of actions in a service under different access levels, specific to an ARN format."""
+        desired_output = ""
+        desired_output = ['ram:associateresourceshare', 'ram:createresourceshare', 'ram:deleteresourceshare', 'ram:disassociateresourceshare', 'ram:updateresourceshare']
+        output = query_action_table_by_arn_type_and_access_level(db_session, "ram", "resource-share",
+                                                                 "Permissions management")
+        print(output)
+        self.assertListEqual(desired_output, output)

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -1,7 +1,8 @@
 import unittest
 from pathlib import Path
 from policy_sentry.shared.database import connect_db
-from policy_sentry.shared.query import query_condition_table_by_name, query_condition_table
+from policy_sentry.shared.query import query_condition_table_by_name, query_condition_table, query_arn_table, \
+    query_arn_table_by_name
 
 HOME = str(Path.home())
 CONFIG_DIRECTORY = '/.policy_sentry/'
@@ -33,4 +34,28 @@ class QueryTestCase(unittest.TestCase):
         }
         output = query_condition_table_by_name(db_session, "cloud9", "cloud9:Permissions")
         self.assertEquals(desired_output, output)
+
+    def test_query_arn_table(self):
+        """Tests function that grabs a list of raw ARNs per service"""
+        desired_output = [
+            'arn:aws:ssm:${Region}:${Account}:document/${DocumentName}',
+            'arn:aws:ssm:${Region}:${Account}:maintenancewindow/${ResourceId}',
+            'arn:aws:ssm:${Region}:${Account}:managed-instance/${ManagedInstanceName}',
+            'arn:aws:ssm:${Region}:${Account}:parameter/${FullyQualifiedParameterName}',
+            'arn:aws:ssm:${Region}:${Account}:patchbaseline/${ResourceId}',
+            'arn:aws:ssm:${Region}:${Account}:session/${ResourceId}',
+            'arn:aws:ssm:${Region}:${Account}:opsitem/${ResourceId}'
+        ]
+        output = query_arn_table(db_session, "ssm")
+        self.assertListEqual(desired_output, output)
+
+    def test_query_arn_table_by_name(self):
+        """Tests function that grabs details about a specific ARN name"""
+        desired_output = {
+            "resource_type_name": "environment",
+            "raw_arn": "arn:aws:cloud9:${Region}:${Account}:environment:${ResourceId}"
+        }
+        output = query_arn_table_by_name(db_session, "cloud9", "environment")
+        self.assertEquals(desired_output, output)
+
 

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -98,7 +98,6 @@ class QueryTestCase(unittest.TestCase):
     def test_query_action_table_by_access_level(self):
         """test_query_action_table_by_access_level: Tests function that gets a list of actions in a
         service under different access levels."""
-        # desired_output = ""
         desired_output = ['ram:acceptresourceshareinvitation', 'ram:associateresourceshare', 'ram:createresourceshare',
                         'ram:deleteresourceshare', 'ram:disassociateresourceshare',
                         'ram:enablesharingwithawsorganization', 'ram:rejectresourceshareinvitation',
@@ -110,7 +109,6 @@ class QueryTestCase(unittest.TestCase):
     def test_query_action_table_by_arn_type_and_access_level(self):
         """test_query_action_table_by_arn_type_and_access_level: Tests a function that gets a list of
         actions in a service under different access levels, specific to an ARN format."""
-        desired_output = ""
         desired_output = ['ram:associateresourceshare', 'ram:createresourceshare', 'ram:deleteresourceshare',
                           'ram:disassociateresourceshare', 'ram:updateresourceshare']
         output = query_action_table_by_arn_type_and_access_level(db_session, "ram", "resource-share",


### PR DESCRIPTION
There are two items that need to be addressed before this is merged.

It will also probably result in another minor release, given that it doesn't break things but is a new feature.

#### 1. Improvements to the Click approach, specific to this new query feature
@mattyjones looking for some help from you about how to organize the command options for the `query` command using Click and its various features.

Take a look at the file `policy_sentry/command/query.py`. You'll notice a comment around line 60, where I point out that there are a lot of different flags/options under the query command. I'd like the available flags to change depending on whether the user provides `action`, `arn`, or `condition` as the value for the `--table` option.

Then we can avoid ~all~ some of the if/else nonsense later in that file, and it will all make more sense.

#### 2. After addressing the item above, adjust the flags for querying the ARN table

Right now, there are two ways that you'd query the ARN table.

```bash
# Get a list of all RAW ARN formats available through the SSM service.
policy_sentry query --table arn --service ssm
# Get the raw ARN format for the `cloud9` ARN with the short name `environment`
policy_sentry query --table arn --service cloud9 --name environment
```

However, I'm not a total fan of how the `--name` flag is used. I'd like to be able to:
1. List available raw ARN formats per service (i.e., `arn:aws:cloud9:${Region}:${Account}:environment:${ResourceId}`)
  - This is the first command above
2. Get more details about a specific ARN format, given the short ARN name
  - This is the second command above
3. List available ARN names (i.e., `environment`)
  - This is not available yet

**Update**: Made Option 3 available in most recent commit. We rigged it with the awkward if/else statements for now, and will explore Click Contexts soon to clean up the help message. But we can do that without breaking changes.
