### PR TITLE
Fixes #35

### DIFF
--- a/policy_sentry/shared/data/access-level-overrides.yml
+++ b/policy_sentry/shared/data/access-level-overrides.yml
@@ -195,6 +195,65 @@ ssm:
         - createdocument
         - createmaintenancewindow
         - createpatchbaseline
+sso:
+    # These were listed as "Write", but should be "Permissions management due to the nature of this service
+    Permissions management:
+        - addmembertogroup
+        - associatedirectory
+        - associateprofile
+        - createalias
+        - createapplicationinstance
+        - createapplicationinstancecertificate
+        - creategroup
+        - createpermissionset
+        - createprofile
+        - createtrust
+        - createuser
+        - deleteapplicationinstance
+        - deleteapplicationinstancecertificate
+        - deletegroup
+        - deletepermissionset
+        - deletepermissionspolicy
+        - deleteprofile
+        - deleteuser
+        - disableuser
+        - disassociatedirectory
+        - disassociateprofile
+        - enableuser
+        - importapplicationinstanceserviceprovidermetadata
+        - putpermissionspolicy
+        - removememberfromgroup
+        - settemporarypassword
+        - startsso
+        - updateapplicationinstanceactivecertificate
+        - updateapplicationinstancedisplaydata
+        - updateapplicationinstanceresponseconfiguration
+        - updateapplicationinstanceresponseschemaconfiguration
+        - updateapplicationinstancesecurityconfiguration
+        - updateapplicationinstanceserviceproviderconfiguration
+        - updateapplicationinstancestatus
+        - updatedirectoryassociation
+        - updategroup
+        - updatepermissionset
+        - updateprofile
+        - updatessoconfiguration
+        - updatetrust
+        - updateuser
+sso-directory:
+    Permissions management:
+        - addmembertogroup
+        - createalias
+        - creategroup
+        - createuser
+        - deletegroup
+        - deleteuser
+        - disableuser
+        - enableuser
+        - removememberfromgroup
+        - updategroup
+        - updatepassword
+        - updateuser
+        - verifyemail
 waf:
     # AWS documentation lists these as "Read"
     Permissions management:


### PR DESCRIPTION
Fixes #35 

### Changed
* access-level-overrides.yml. Took all of the actions previously listed as `Write` for services `sso` and `sso-directory` and made them `Permissions management` instead.