### PR TITLE
Fixes #55 - support for GovCloud and non-standard AWS partitions

### DIFF
--- a/policy_sentry/shared/database.py
+++ b/policy_sentry/shared/database.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy import create_engine, and_
 from sqlalchemy import Column, Integer, String
 from policy_sentry.shared.arns import get_service_from_arn, get_resource_from_arn, get_resource_path_from_arn, \
-    get_region_from_arn, get_account_from_arn
+    get_region_from_arn, get_account_from_arn, get_partition_from_arn
 from policy_sentry.shared.config import get_action_access_level_overrides_from_yml, determine_access_level_override
 from policy_sentry.shared.scrape import get_html
 from policy_sentry.shared.conditions import get_service_from_condition_key, get_comma_separated_condition_keys
@@ -276,11 +276,11 @@ def build_arn_table(db_session, service):
                         condition_keys = table['data'][i][2]
                     db_session.add(ArnTable(
                         resource_type_name=table['data'][i][0],
-                        raw_arn=str(table['data'][i][1]).replace(
-                            "${Partition}", "aws"),
-                        # raw_arn=get_string_arn(table['data'][i][1]),
+                        # raw_arn=str(table['data'][i][1]).replace(
+                        #     "${Partition}", "aws"),
+                        raw_arn=str(table['data'][i][1]),
                         arn='arn',
-                        partition='aws',
+                        partition=get_partition_from_arn(table['data'][i][1]),
                         service=get_service_from_arn(table['data'][i][1]),
                         region=get_region_from_arn(table['data'][i][1]),
                         account=get_account_from_arn(table['data'][i][1]),

--- a/test/test_arn_action_group.py
+++ b/test/test_arn_action_group.py
@@ -16,7 +16,7 @@ class ArnActionGroupTestCase(unittest.TestCase):
                 'arn': 'arn:aws:s3:::example-org-s3-access-logs',
                 'service': 's3',
                 'access_level': 'Permissions management',
-                'arn_format': 'arn:aws:s3:::${BucketName}',
+                'arn_format': 'arn:${Partition}:s3:::${BucketName}',
                 'actions': []
             }
         ]
@@ -33,7 +33,7 @@ class ArnActionGroupTestCase(unittest.TestCase):
                 'arn': 'arn:aws:s3:::example-org-s3-access-logs',
                 'service': 's3',
                 'access_level': 'Permissions management',
-                'arn_format': 'arn:aws:s3:::${BucketName}',
+                'arn_format': 'arn:${Partition}:s3:::${BucketName}',
                 'actions': [
                     "s3:deletebucketpolicy",
                     "s3:putbucketacl",

--- a/test/test_arns.py
+++ b/test/test_arns.py
@@ -22,19 +22,19 @@ class ArnsTestCase(unittest.TestCase):
     def test_does_arn_match_case_bucket(self):
         # Case 1: arn:partition:service:region:account-id:resource
         arn_to_test = "arn:aws:s3:::bucket_name"
-        arn_in_database = "arn:aws:s3:::${BucketName}"
+        arn_in_database = "arn:${Partition}:s3:::${BucketName}"
         self.assertTrue(does_arn_match(arn_to_test, arn_in_database))
 
     def test_does_arn_match_case_1(self):
         # Case 1: arn:partition:service:region:account-id:resource
         arn_to_test = "arn:aws:codecommit:us-east-1:123456789012:MyDemoRepo"
-        arn_in_database = "arn:aws:codecommit:${Region}:${Account}:${RepositoryName}"
+        arn_in_database = "arn:${Partition}:codecommit:${Region}:${Account}:${RepositoryName}"
         self.assertTrue(does_arn_match(arn_to_test, arn_in_database))
 
     def test_does_arn_match_case_2(self):
         # Case 2: arn:partition:service:region:account-id:resourcetype/resource
         arn_to_test = "arn:aws:ssm:us-east-1:123456789012:parameter/test"
-        arn_in_database = "arn:aws:ssm:${Region}:${Account}:parameter/${FullyQualifiedParameterName}"
+        arn_in_database = "arn:${Partition}:ssm:${Region}:${Account}:parameter/${FullyQualifiedParameterName}"
         self.assertTrue(does_arn_match(arn_to_test, arn_in_database))
 
     # This one is failing
@@ -48,19 +48,19 @@ class ArnsTestCase(unittest.TestCase):
     def test_does_arn_match_case_4(self):
         # Case 4: arn:partition:service:region:account-id:resourcetype/resource:qualifier
         arn_to_test = "arn:aws:batch:region:account-id:job-definition/job-name:revision"
-        arn_in_database = "arn:aws:batch:${Region}:${Account}:job-definition/${JobDefinitionName}:${Revision}"
+        arn_in_database = "arn:${Partition}:batch:${Region}:${Account}:job-definition/${JobDefinitionName}:${Revision}"
         self.assertTrue(does_arn_match(arn_to_test, arn_in_database))
 
     def test_does_arn_match_case_5(self):
         # Case 5: arn:partition:service:region:account-id:resourcetype:resource
         arn_to_test = "arn:aws:states:region:account-id:stateMachine:stateMachineName"
-        arn_in_database = "arn:aws:states:${Region}:${Account}:stateMachine:${StateMachineName}"
+        arn_in_database = "arn:${Partition}:states:${Region}:${Account}:stateMachine:${StateMachineName}"
         self.assertTrue(does_arn_match(arn_to_test, arn_in_database))
 
     def test_does_arn_match_case_6(self):
         # Case 6: arn:partition:service:region:account-id:resourcetype:resource:qualifier
         arn_to_test = "arn:aws:states:region:account-id:execution:stateMachineName:executionName"
-        arn_in_database = "arn:aws:states:${Region}:${Account}:execution:${StateMachineName}:${ExecutionId}"
+        arn_in_database = "arn:${Partition}:states:${Region}:${Account}:execution:${StateMachineName}:${ExecutionId}"
         self.assertTrue(does_arn_match(arn_to_test, arn_in_database))
 
     # def test_does_arn_match_case_greengrass(self):

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -37,9 +37,9 @@ class QueryTestCase(unittest.TestCase):
     def test_query_arn_table_for_raw_arns(self):
         """test_query_arn_table_for_raw_arns: Tests function that grabs a list of raw ARNs per service"""
         desired_output = [
-            "arn:aws:s3:::${BucketName}",
-            "arn:aws:s3:::${BucketName}/${ObjectName}",
-            "arn:aws:s3:${Region}:${Account}:job/${JobId}"
+            "arn:${Partition}:s3:::${BucketName}",
+            "arn:${Partition}:s3:::${BucketName}/${ObjectName}",
+            "arn:${Partition}:s3:${Region}:${Account}:job/${JobId}"
         ]
         output = query_arn_table_for_raw_arns(db_session, "s3")
         self.assertListEqual(desired_output, output)
@@ -47,9 +47,9 @@ class QueryTestCase(unittest.TestCase):
     def test_query_arn_table_for_arn_types(self):
         """test_query_arn_table_for_arn_types: Tests function that grabs arn_type and raw_arn pairs"""
         desired_output = {
-            "bucket": "arn:aws:s3:::${BucketName}",
-            "object": "arn:aws:s3:::${BucketName}/${ObjectName}",
-            "job": "arn:aws:s3:${Region}:${Account}:job/${JobId}"
+            "bucket": "arn:${Partition}:s3:::${BucketName}",
+            "object": "arn:${Partition}:s3:::${BucketName}/${ObjectName}",
+            "job": "arn:${Partition}:s3:${Region}:${Account}:job/${JobId}"
         }
         output = query_arn_table_for_arn_types(db_session, "s3")
         print(output)
@@ -60,7 +60,7 @@ class QueryTestCase(unittest.TestCase):
         """test_query_arn_table_by_name: Tests function that grabs details about a specific ARN name"""
         desired_output = {
             "resource_type_name": "environment",
-            "raw_arn": "arn:aws:cloud9:${Region}:${Account}:environment:${ResourceId}",
+            "raw_arn": "arn:${Partition}:cloud9:${Region}:${Account}:environment:${ResourceId}",
             "condition_keys": None
         }
         output = query_arn_table_by_name(db_session, "cloud9", "environment")
@@ -85,7 +85,7 @@ class QueryTestCase(unittest.TestCase):
                     'action': 'ram:createresourceshare',
                     'description': 'Create resource share with provided resource(s) and/or principal(s)',
                     'access_level': 'Permissions management',
-                    'resource_arn_format': 'arn:aws:ram:${Region}:${Account}:resource-share/${ResourcePath}',
+                    'resource_arn_format': 'arn:${Partition}:ram:${Region}:${Account}:resource-share/${ResourcePath}',
                     'condition_keys': [
                         'ram:RequestedResourceType',
                         'ram:ResourceArn',

--- a/test/test_write_policy.py
+++ b/test/test_write_policy.py
@@ -58,7 +58,7 @@ class WritePolicyActionsTestCase(unittest.TestCase):
                             "kms:creategrant"
                         ],
                         "Resource": [
-                            "arn:aws:kms:${Region}:${Account}:key/${KeyId}"
+                            "arn:${Partition}:kms:${Region}:${Account}:key/${KeyId}"
                         ]
                     },
                     {

--- a/test/test_write_policy.py
+++ b/test/test_write_policy.py
@@ -40,6 +40,65 @@ class WritePolicyCrudTestCase(unittest.TestCase):
         # print(policy)
         self.assertEqual(policy, desired_output)
 
+    def test_write_policy_govcloud(self):
+        """Tests ARNs with the partition `aws-us-gov` instead of `aws`"""
+        arn_action_group = ArnActionGroup()
+        govcloud_arn_list_from_user = ["arn:aws-us-gov:s3:::example-org-s3-access-logs"]
+        access_level = "Permissions management"
+        desired_output = {
+            'Version': '2012-10-17',
+            'Statement': [
+                {
+                    'Sid': 'S3PermissionsmanagementBucket',
+                    'Effect': 'Allow',
+                    'Action': [
+                        's3:deletebucketpolicy',
+                        's3:putbucketacl',
+                        's3:putbucketpolicy',
+                        's3:putbucketpublicaccessblock'
+                    ],
+                    'Resource': [
+                        'arn:aws-us-gov:s3:::example-org-s3-access-logs'
+                    ]
+                }
+            ]
+        }
+        arn_action_group.add(db_session, govcloud_arn_list_from_user, access_level)
+        arn_action_group.update_actions_for_raw_arn_format(db_session)
+        arn_dict = arn_action_group.get_policy_elements(db_session)
+        policy = print_policy(arn_dict, db_session)
+        # print(policy)
+        self.assertEqual(policy, desired_output)
+
+    def test_write_policy_beijing(self):
+        """Tests ARNs with the partiion `aws-cn` instead of just `aws`"""
+        arn_action_group = ArnActionGroup()
+        govcloud_arn_list_from_user = ["arn:aws-cn:s3:::example-org-s3-access-logs"]
+        access_level = "Permissions management"
+        desired_output = {
+            'Version': '2012-10-17',
+            'Statement': [
+                {
+                    'Sid': 'S3PermissionsmanagementBucket',
+                    'Effect': 'Allow',
+                    'Action': [
+                        's3:deletebucketpolicy',
+                        's3:putbucketacl',
+                        's3:putbucketpolicy',
+                        's3:putbucketpublicaccessblock'
+                    ],
+                    'Resource': [
+                        'arn:aws-cn:s3:::example-org-s3-access-logs'
+                    ]
+                }
+            ]
+        }
+        arn_action_group.add(db_session, govcloud_arn_list_from_user, access_level)
+        arn_action_group.update_actions_for_raw_arn_format(db_session)
+        arn_dict = arn_action_group.get_policy_elements(db_session)
+        policy = print_policy(arn_dict, db_session)
+        # print(policy)
+        self.assertEqual(policy, desired_output)
 
 actions_test_data_1 = ['kms:CreateCustomKeyStore', 'kms:CreateGrant']
 actions_test_data_2 = ['ec2:AuthorizeSecurityGroupEgress', 'ec2:AuthorizeSecurityGroupIngress']


### PR DESCRIPTION
The database now builds `${Partition}`, as provided in the AWS docs, instead of simply replacing it with `aws`. This provides support for the non-standard AWS partitions, like GovCloud, `aws-cn`, or ~big brother~ TS level datacenters.