### PR TITLE
Renamed write-policy template types from `roles` to `policy` since this makes more sense

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Added
 * `utils/run_tests.sh` to make local testing easier before having TravisCI do all the work. Updated this in the documentation. Fixed an issue with the tasks.py for the uninstall-package invoke command.
 * `--version` flag. Fixes #48
+* Renamed write-policy template's `roles_with_crud_levels` and `roles_with_actions` to `policy_with_crud_levels` and `policy_with_actions` since this makes way more sense. Discussion is in #65. Version bump to 0.7.0 because this creates breaking changes.
 
 ## 2019-12-19
 ## Changed

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ policy_sentry create-template --name myRole --output-file crud.yml --template-ty
 It will generate a file like this:
 
 ```yaml
-roles_with_crud_levels:
+policy_with_crud_levels:
 - name: myRole
   description: ''
   arn: ''
@@ -102,7 +102,7 @@ roles_with_crud_levels:
 Then just fill it out:
 
 ```yaml
-roles_with_crud_levels:
+policy_with_crud_levels:
 - name: myRole
   description: 'Justification for privileges'
   arn: 'arn:aws:iam::123456789102:role/myRole'

--- a/docs/introduction/home.rst
+++ b/docs/introduction/home.rst
@@ -56,7 +56,7 @@ It will generate a file like this:
 
 .. code-block:: yaml
 
-   roles_with_crud_levels:
+   policy_with_crud_levels:
    - name: myRole
      description: '' # Insert description
      arn: '' # Insert the ARN of the role that will use this
@@ -75,7 +75,7 @@ Then just fill it out:
 
 .. code-block:: yaml
 
-   roles_with_crud_levels:
+   policy_with_crud_levels:
    - name: myRole
      description: 'Justification for privileges'
      arn: 'arn:aws:iam::123456789102:role/myRole'

--- a/docs/user-guide/write-policy.rst
+++ b/docs/user-guide/write-policy.rst
@@ -36,7 +36,7 @@ Instructions
 
 .. code-block:: yaml
 
-    roles_with_crud_levels:
+    policy_with_crud_levels:
     - name: myRole
       description: ''
       arn: ''
@@ -59,7 +59,7 @@ Instructions
 
 .. code-block:: yaml
 
-    roles_with_crud_levels:
+    policy_with_crud_levels:
     - name: myRole
       description: 'Justification for privileges'
       arn: 'arn:aws:iam::123456789102:role/myRole'
@@ -172,7 +172,7 @@ Instructions
 
 .. code-block:: yaml
 
-    roles_with_actions:
+    policy_with_actions:
     - name: myRole
       description: '' # Insert value here
       arn: '' # Insert value here
@@ -183,7 +183,7 @@ Instructions
 
 .. code-block:: yaml
 
-    roles_with_actions:
+    policy_with_actions:
     - name: 'RoleNameWithActions'
       description: 'Justification for privileges' # for auditability
       arn: 'arn:aws:iam::123456789102:role/myRole' # for auditability

--- a/examples/input-dir/policy-puma.yml
+++ b/examples/input-dir/policy-puma.yml
@@ -1,4 +1,4 @@
-roles_with_crud_levels:
+policy_with_crud_levels:
 - name: 'RoleNameWithCRUD'
   description: 'Why I need these privs'
   arn: 'arn:aws:iam::123456789012:role/RiskyEC2'

--- a/examples/input-dir/policy-zebu.yml
+++ b/examples/input-dir/policy-zebu.yml
@@ -1,4 +1,4 @@
-roles_with_crud_levels:
+policy_with_crud_levels:
 - name: 'RoleNameWithCRUD'
   description: 'Why I need these privs'
   arn: 'arn:aws:iam::123456789012:role/RiskyEC2'

--- a/examples/terraform/environments/iam-resources/files/example-role-jpwdp.yml.example
+++ b/examples/terraform/environments/iam-resources/files/example-role-jpwdp.yml.example
@@ -1,4 +1,4 @@
-roles_with_crud_levels:
+policy_with_crud_levels:
 - name: example-role-jpwdp
   description: bruh
   arn: arn:aws:iam::123456789012:role/example-role-jpwdp

--- a/examples/terraform/modules/generate-policy_sentry-yml/templates/vibranium-template.yml
+++ b/examples/terraform/modules/generate-policy_sentry-yml/templates/vibranium-template.yml
@@ -1,4 +1,4 @@
-roles_with_crud_levels:
+policy_with_crud_levels:
 - name: ${policy_sentry_role_name}
   description: ${policy_sentry_role_description}
   arn: ${policy_sentry_role_arn}

--- a/examples/yml/actions.yml
+++ b/examples/yml/actions.yml
@@ -1,5 +1,5 @@
 # Generate my policy when I know the Actions
-roles_with_actions:
+policy_with_actions:
 - name: 'RoleNameWithActions'
   description: 'Why I need these privs'
   arn: 'arn:aws:iam::123456789102:role/RiskyEC2'

--- a/examples/yml/crud-with-wildcard.yml
+++ b/examples/yml/crud-with-wildcard.yml
@@ -1,4 +1,4 @@
-roles_with_crud_levels:
+policy_with_crud_levels:
 - name: 'RoleNameWithCRUD'
   description: 'Why I need these privs'
   arn: 'arn:aws:iam::123456789012:role/RiskyEC2'

--- a/examples/yml/crud.yml
+++ b/examples/yml/crud.yml
@@ -1,4 +1,4 @@
-roles_with_crud_levels:
+policy_with_crud_levels:
 - name: 'RoleNameWithCRUD'
   description: 'Why I need these privs'
   arn: 'arn:aws:iam::123456789012:role/RiskyEC2'

--- a/policy_sentry/bin/policy_sentry
+++ b/policy_sentry/bin/policy_sentry
@@ -2,7 +2,7 @@
 """
     policy_sentry is a tool for generating least-privilege IAM Policies.
 """
-__version__ = '0.6.3'
+__version__ = '0.7.0'
 import click
 from policy_sentry import command
 

--- a/policy_sentry/bin/policy_sentry
+++ b/policy_sentry/bin/policy_sentry
@@ -2,7 +2,7 @@
 """
     policy_sentry is a tool for generating least-privilege IAM Policies.
 """
-__version__ = '0.7.0'
+__version__ = '0.6.3'
 import click
 from policy_sentry import command
 

--- a/policy_sentry/command/write_policy.py
+++ b/policy_sentry/command/write_policy.py
@@ -55,10 +55,10 @@ def write_policy_with_actions(cfg, db_session, minimize_statement=False):
     """
     Writes an IAM policy given a dict containing lists of actions.
     """
-    roles_with_actions = Roles()
-    roles_with_actions.process_actions_config(cfg)
+    policy_with_actions = Roles()
+    policy_with_actions.process_actions_config(cfg)
     supplied_actions = []
-    for role in roles_with_actions.get_roles():
+    for role in policy_with_actions.get_roles():
         supplied_actions.extend(role[3].copy())
     supplied_actions = get_dependent_actions(db_session, supplied_actions)
     arn_action_group = ArnActionGroup()

--- a/policy_sentry/shared/policy.py
+++ b/policy_sentry/shared/policy.py
@@ -106,7 +106,7 @@ class ArnActionGroup:
         """
         try:
             for category in cfg:
-                if category == 'roles_with_crud_levels':
+                if category == 'policy_with_crud_levels':
                     for principal in cfg[category]:
                         if 'wildcard' in principal.keys():
                             if principal['wildcard'] is not None:

--- a/policy_sentry/shared/roles.py
+++ b/policy_sentry/shared/roles.py
@@ -33,7 +33,7 @@ class Roles:
         """Given the YAML file used for the list of actions config, process it."""
         try:
             for category in cfg:
-                if category == 'roles_with_actions':
+                if category == 'policy_with_actions':
                     for principal in cfg[category]:
                         self.add_role(
                             [

--- a/policy_sentry/shared/template.py
+++ b/policy_sentry/shared/template.py
@@ -4,7 +4,7 @@ These can be used for generating policies
 from jinja2 import Template
 
 ACTIONS_TEMPLATE = '''# Generate my policy when I know the Actions
-roles_with_actions:
+policy_with_actions:
 - name: {{ name }}
   description: ''
   arn: ''
@@ -13,7 +13,7 @@ roles_with_actions:
 '''
 
 CRUD_TEMPLATE = '''# Generate my policy when I know the access levels and ARNs
-roles_with_crud_levels:
+policy_with_crud_levels:
 - name: {{ name }}
   description: ''
   arn: ''

--- a/test/test_template.py
+++ b/test/test_template.py
@@ -5,7 +5,7 @@ from policy_sentry.shared.template import create_actions_template, create_crud_t
 class TemplateTestCase(unittest.TestCase):
     def test_actions_template(self):
         desired_msg = """# Generate my policy when I know the Actions
-roles_with_actions:
+policy_with_actions:
 - name: myrole
   description: ''
   arn: ''
@@ -16,7 +16,7 @@ roles_with_actions:
 
     def test_crud_template(self):
         desired_msg = """# Generate my policy when I know the access levels and ARNs
-roles_with_crud_levels:
+policy_with_crud_levels:
 - name: myrole
   description: ''
   arn: ''

--- a/test/test_write_policy.py
+++ b/test/test_write_policy.py
@@ -146,7 +146,7 @@ class WritePolicyPreventWildcardEscalation(unittest.TestCase):
     def test_wildcard_when_not_necessary(self):
         """test_wildcard_when_not_necessary: Attempts bypass of CRUD mode wildcard-only"""
         cfg = {
-            'roles_with_crud_levels': [
+            'policy_with_crud_levels': [
                 {
                     'name': 'RoleNameWithCRUD',
                     'description': 'Why I need these privs',

--- a/test/test_yaml_validation.py
+++ b/test/test_yaml_validation.py
@@ -9,7 +9,7 @@ db_session = connect_db(DATABASE_FILE_PATH)
 
 
 valid_cfg_for_crud = {
-    "roles_with_crud_levels": [
+    "policy_with_crud_levels": [
         {
             "name": "RoleNameWithCRUD",
             "description": "Why I need these privs",
@@ -44,7 +44,7 @@ valid_cfg_for_crud = {
 }
 
 valid_cfg_for_actions = {
-    "roles_with_actions": [
+    "policy_with_actions": [
         {
             "name": "RoleNameWithActions",
             "description": "Why I need these privs",
@@ -69,7 +69,7 @@ class YamlValidationOverallTestCase(unittest.TestCase):
     #     :return:
     #     """
     #     cfg_multiple_roles_in_file = {
-    #         "roles_with_actions": [
+    #         "policy_with_actions": [
     #             {
     #                 "name": "RoleNameWithActions",
     #                 "description": "Why I need these privs",
@@ -101,11 +101,11 @@ class YamlValidationOverallTestCase(unittest.TestCase):
     #
     # def test_both_roles_in_file(self):
     #     """
-    #     test_both_roles_in_file: write-policy when the YAML file contains both roles_with_crud_levels and roles_with_actions in the file (should only contain one)
+    #     test_both_roles_in_file: write-policy when the YAML file contains both policy_with_crud_levels and policy_with_actions in the file (should only contain one)
     #     :return:
     #     """
     #     cfg_both_roles_in_file = {
-    #         "roles_with_actions": [
+    #         "policy_with_actions": [
     #             {
     #                 "name": "RoleNameWithActions",
     #                 "description": "Why I need these privs",
@@ -118,7 +118,7 @@ class YamlValidationOverallTestCase(unittest.TestCase):
     #                 ]
     #             },
     #         ],
-    #         "roles_with_crud_levels": [
+    #         "policy_with_crud_levels": [
     #             {
     #                 "name": "DuplicateRoleNameWithActions",
     #                 "description": "Why I need these privs",
@@ -164,8 +164,8 @@ class YamlValidationOverallTestCase(unittest.TestCase):
 
     # def test_missing_category_as_dict(self):
     #     """
-    #     Test case: write-policy when the YAML file does not contain roles_with_crud_levels or
-    #     roles_with_actions, and the input is as a dict instead of a list
+    #     Test case: write-policy when the YAML file does not contain policy_with_crud_levels or
+    #     policy_with_actions, and the input is as a dict instead of a list
     #     :return:
     #     """
     #     cfg_with_missing_category = {
@@ -189,7 +189,7 @@ class YamlValidationOverallTestCase(unittest.TestCase):
         :return:
         """
         cfg_with_missing_name = {
-            "roles_with_actions": [
+            "policy_with_actions": [
                 {
                     "description": "Why I need these privs",
                     "arn": "arn:aws:iam::123456789102:role/RiskyEC2",
@@ -212,7 +212,7 @@ class YamlValidationOverallTestCase(unittest.TestCase):
         :return:
         """
         cfg_with_missing_description = {
-            "roles_with_actions": [
+            "policy_with_actions": [
                 {
                     "name": "RoleNameWithActions",
                     "arn": "arn:aws:iam::123456789102:role/RiskyEC2",
@@ -235,7 +235,7 @@ class YamlValidationOverallTestCase(unittest.TestCase):
         :return:
         """
         cfg_with_missing_actions = {
-            "roles_with_actions": [
+            "policy_with_actions": [
                 {
                     "name": "RoleNameWithActions",
                     "description": "Why I need these privs",
@@ -263,7 +263,7 @@ class YamlValidationCrudTestCase(unittest.TestCase):
         """
 
         crud_file_input = {
-            "roles_with_crud_levels": [
+            "policy_with_crud_levels": [
                 {
                     "name": "RoleNameWithCRUD",
                     "description": "Why I need these privs",
@@ -292,7 +292,7 @@ class YamlValidationCrudTestCase(unittest.TestCase):
         :return:
         """
         crud_file_input = {
-            "roles_with_crud_levels": [
+            "policy_with_crud_levels": [
                 {
                     "name": "RoleNameWithCRUD",
                     "description": "Why I need these privs",
@@ -329,7 +329,7 @@ class YamlValidationActionsTestCase(unittest.TestCase):
         :return:
         """
         cfg_with_missing_actions = {
-            "roles_with_actions": [
+            "policy_with_actions": [
                 {
                     "name": "RoleNameWithActions",
                     "description": "Why I need these privs",


### PR DESCRIPTION
Renamed write-policy template's `roles_with_crud_levels` and `roles_with_actions` to `policy_with_crud_levels` and `policy_with_actions` since this makes way more sense. Discussion is in #65.