### PR TITLE
Fixed an issue where keys in the condition keys table were being stored with extra spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 2020-01-04
+### Changed
+* Fixed an issue where condition keys were being stored as `'aws:RequestTag/$  {  TagKey}'` - we need it without extra spaces.
+
 ## 2020-01-03
 ### Added
 * Docker support

--- a/policy_sentry/shared/database.py
+++ b/policy_sentry/shared/database.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy import create_engine, and_
 from sqlalchemy import Column, Integer, String
 from policy_sentry.configuration.access_level_overrides import get_action_access_level_overrides_from_yml
+from policy_sentry.scraping.awsdocs import chomp
 from policy_sentry.scraping.scrape import get_html
 from policy_sentry.shared.constants import HTML_DIRECTORY_PATH
 from policy_sentry.util.access_levels import determine_access_level_override
@@ -325,10 +326,11 @@ def build_condition_table(db_session, service):
                         temp_description = 'None'
                     else:
                         temp_description = table['data'][i][1]
-
+                    # Name: sometimes there are random spaces in the string, like 'aws:RequestTag/$  {  TagKey}'.
+                    condition_key_name = table['data'][i][0].replace(" ", "")
                     db_session.add(ConditionTable(
                         service=service,
-                        condition_key_name=table['data'][i][0],
+                        condition_key_name=condition_key_name,
                         condition_key_service=get_service_from_condition_key(
                             table['data'][i][0]),
                         description=temp_description,

--- a/policy_sentry/shared/database.py
+++ b/policy_sentry/shared/database.py
@@ -11,7 +11,6 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy import create_engine, and_
 from sqlalchemy import Column, Integer, String
 from policy_sentry.configuration.access_level_overrides import get_action_access_level_overrides_from_yml
-from policy_sentry.scraping.awsdocs import chomp
 from policy_sentry.scraping.scrape import get_html
 from policy_sentry.shared.constants import HTML_DIRECTORY_PATH
 from policy_sentry.util.access_levels import determine_access_level_override


### PR DESCRIPTION
It was being stored like `aws:RequestTag/$  {  TagKey}`. Fixed it here.