### PR TITLE
Tweak some functions to allow for direct method calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,22 @@
 # Changelog
+## 2020-01-09
+### Breaking changes
+* Templates:
+  - `arn` is now `role_arn` to avoid confusion when writing templates
+  - `tag` is now `tagging` to avoid inconsistency when writing templates
+
+### Changed
+* Template:
+  - `arn` is now `role_arn` to avoid confusion when writing templates
+  - `tag` is now `tagging` to avoid inconsistency when writing templates
+* `command/write_policy/write_policy_with_actions` and `command/write_policy/write_policy_with_access_levels` can be called directly.
+* `writing/template/` now exposes `get_crud_template_dict` and `get_actions_template_dict` so developers can create the templates by calling the library. We might add on additional ones so they can just pass in lists without having to know the format, but not right now. They can pass that into `write_policy_with_actions` and `write_policy_with_access_levels`
+
+
+## 2020-01-08
+* Fixed an issue where the bundled database was being appended to instead of overwritten when going through an update.
+* Documentation updates
+* 0.6.6 release
 ## 2020-01-07
 ### Added
 * PyInvoke commands to support the Sphinx documentation testing locally

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,9 @@
 # Changelog
 ## 2020-01-09
-### Breaking changes
-* Templates:
-  - `arn` is now `role_arn` to avoid confusion when writing templates
-  - `tag` is now `tagging` to avoid inconsistency when writing templates
+
 
 ### Changed
+* 0.6.7 release to avoid issues with breaking changes
 * Template:
   - `arn` is now `role_arn` to avoid confusion when writing templates
   - `tag` is now `tagging` to avoid inconsistency when writing templates

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ It will generate a file like this:
 policy_with_crud_levels:
 - name: myRole
   description: ''
-  arn: ''
+  role_arn: ''
   # Insert ARNs under each access level below
   # If you do not need to use certain access levels, delete them.
   read:
@@ -89,7 +89,7 @@ policy_with_crud_levels:
     - ''
   list:
     - ''
-  tag:
+  tagging:
     - ''
   permissions-management:
     - ''
@@ -105,14 +105,14 @@ Then just fill it out:
 policy_with_crud_levels:
 - name: myRole
   description: 'Justification for privileges'
-  arn: 'arn:aws:iam::123456789102:role/myRole'
+  role_arn: 'arn:aws:iam::123456789102:role/myRole'
   read:
     - 'arn:aws:ssm:us-east-1:123456789012:parameter/myparameter'
   write:
     - 'arn:aws:ssm:us-east-1:123456789012:parameter/myparameter'
   list:
     - 'arn:aws:ssm:us-east-1:123456789012:parameter/myparameter'
-  tag:
+  tagging:
     - 'arn:aws:secretsmanager:us-east-1:123456789012:secret:mysecret'
   permissions-management:
     - 'arn:aws:secretsmanager:us-east-1:123456789012:secret:mysecret'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -65,9 +65,6 @@ Navigate below to get started with Policy Sentry!
    :caption: Library Usage
 
    library-usage/index.rst
-   library-usage/reference/index.rst
-   library-usage/examples/index.rst
-
 
 ..
     .. toctree::
@@ -75,11 +72,6 @@ Navigate below to get started with Policy Sentry!
        :caption: Library reference
        library-usage/reference/index
 
-..
-    .. toctree::
-       :maxdepth: 2
-       :caption: Library examples
-       library-usage/examples/index
 
 .. toctree::
    :maxdepth: 1

--- a/docs/introduction/home.rst
+++ b/docs/introduction/home.rst
@@ -59,14 +59,14 @@ It will generate a file like this:
    policy_with_crud_levels:
    - name: myRole
      description: '' # Insert description
-     arn: '' # Insert the ARN of the role that will use this
+     role_arn: '' # Insert the ARN of the role that will use this
      read:
        - '' # Insert ARNs for Read access
      write:
        - '' # Insert ARNs...
      list:
        - '' # Insert ARNs...
-     tag:
+     tagging:
        - '' # Insert ARNs...
      permissions-management:
        - '' # Insert ARNs...
@@ -78,14 +78,14 @@ Then just fill it out:
    policy_with_crud_levels:
    - name: myRole
      description: 'Justification for privileges'
-     arn: 'arn:aws:iam::123456789102:role/myRole'
+     role_arn: 'arn:aws:iam::123456789102:role/myRole'
      read:
        - 'arn:aws:ssm:us-east-1:123456789012:parameter/myparameter'
      write:
        - 'arn:aws:ssm:us-east-1:123456789012:parameter/myparameter'
      list:
        - 'arn:aws:ssm:us-east-1:123456789012:parameter/myparameter'
-     tag:
+     tagging:
        - 'arn:aws:secretsmanager:us-east-1:123456789012:secret:mysecret'
      permissions-management:
        - 'arn:aws:secretsmanager:us-east-1:123456789012:secret:mysecret'

--- a/docs/library-usage/examples/analysis.rst
+++ b/docs/library-usage/examples/analysis.rst
@@ -1,5 +1,5 @@
-Analysis
-========
+Analyzing Policies
+==================
 
 The following are examples of how to leverage some of the functions available from Policy Sentry. The functions selected are likely to be of most interest to other developers.
 

--- a/docs/library-usage/examples/index.rst
+++ b/docs/library-usage/examples/index.rst
@@ -8,4 +8,5 @@ These are examples for the modules and functions that will be of interest for de
    :caption: Library examples
 
    querying
+   writing
    analysis

--- a/docs/library-usage/examples/querying.rst
+++ b/docs/library-usage/examples/querying.rst
@@ -1,5 +1,5 @@
-Querying
-========
+Querying the IAM Database
+=========================
 
 The following are examples of how to leverage some of the functions available from Policy Sentry. The functions selected are likely to be of most interest to other developers.
 

--- a/docs/library-usage/examples/writing.rst
+++ b/docs/library-usage/examples/writing.rst
@@ -1,0 +1,22 @@
+Writing Policies
+================
+
+The following are examples of how to leverage some of the functions available from Policy Sentry. The functions selected are likely to be of most interest to other developers.
+
+These ones refer to leveraging Policy Sentry as a library to write IAM policies.
+
+Actions Mode: Writing Policies by providing a list of Actions
+-------------------------------------------------------------
+
+
+.. literalinclude:: ../../../examples/library-usage/writing/write_policy_with_actions.py
+   :language: python
+   :emphasize-lines: 15-18
+
+
+CRUD Mode: Writing Policies by Access Levels and ARNs
+-----------------------------------------------------
+
+.. literalinclude:: ../../../examples/library-usage/writing/write_policy_with_access_levels.py
+   :language: python
+   :emphasize-lines: 13-26

--- a/docs/library-usage/index.rst
+++ b/docs/library-usage/index.rst
@@ -9,6 +9,8 @@ Policy Sentry can be used as a Python library. Check out this documentation for 
    :caption: Library Usage
 
    getting-started-with-the-library
+   examples/index.rst
+   reference/index.rst
 
 ..
     .. toctree::

--- a/docs/user-guide/analyze-policy.rst
+++ b/docs/user-guide/analyze-policy.rst
@@ -1,7 +1,7 @@
 Analyzing Policies
 ##################
 
-``analyze-iam-policy``: Reads policies downloaded locally, and expands the wildcards (like ``s3:List*`` if necessary, and audits them to see if certain IAM actions are permitted.
+``analyze``: Reads policies downloaded locally, and expands the wildcards (like ``s3:List*`` if necessary, and audits them to see if certain IAM actions are permitted.
 
 Motivation
 ^^^^^^^^^^

--- a/docs/user-guide/write-policy.rst
+++ b/docs/user-guide/write-policy.rst
@@ -39,7 +39,7 @@ Instructions
     policy_with_crud_levels:
     - name: myRole
       description: ''
-      arn: ''
+      role_arn: ''
       # Insert ARNs below
       read:
         - ''
@@ -47,7 +47,7 @@ Instructions
         - ''
       list:
         - ''
-      tag:
+      tagging:
         - ''
       permissions-management:
         - ''
@@ -62,14 +62,14 @@ Instructions
     policy_with_crud_levels:
     - name: myRole
       description: 'Justification for privileges'
-      arn: 'arn:aws:iam::123456789102:role/myRole'
+      role_arn: 'arn:aws:iam::123456789102:role/myRole'
       read:
         - 'arn:aws:ssm:us-east-1:123456789012:parameter/myparameter'
       write:
         - 'arn:aws:ssm:us-east-1:123456789012:parameter/myparameter'
       list:
         - 'arn:aws:ssm:us-east-1:123456789012:parameter/myparameter'
-      tag:
+      tagging:
         - 'arn:aws:secretsmanager:us-east-1:123456789012:secret:mysecret'
       permissions-management:
         - 'arn:aws:secretsmanager:us-east-1:123456789012:secret:mysecret'
@@ -175,7 +175,7 @@ Instructions
     policy_with_actions:
     - name: myRole
       description: '' # Insert value here
-      arn: '' # Insert value here
+      role_arn: '' # Insert value here
       actions:
       - ''  # Fill in your IAM actions here
 
@@ -186,7 +186,7 @@ Instructions
     policy_with_actions:
     - name: 'RoleNameWithActions'
       description: 'Justification for privileges' # for auditability
-      arn: 'arn:aws:iam::123456789102:role/myRole' # for auditability
+      role_arn: 'arn:aws:iam::123456789102:role/myRole' # for auditability
       actions:
         - kms:CreateGrant
         - kms:CreateCustomKeyStore

--- a/examples/input-dir/policy-puma.yml
+++ b/examples/input-dir/policy-puma.yml
@@ -1,7 +1,7 @@
 policy_with_crud_levels:
 - name: 'RoleNameWithCRUD'
   description: 'Why I need these privs'
-  arn: 'arn:aws:iam::123456789012:role/RiskyEC2'
+  role_arn: 'arn:aws:iam::123456789012:role/RiskyEC2'
   read:
     - arn:aws:s3:::example-org-sbx-vmimport
     - arn:aws:s3:::example-kinnaird
@@ -18,7 +18,7 @@ policy_with_crud_levels:
   list:
     - arn:aws:s3:::example-org-flow-logs
     - arn:aws:s3:::example-org-sbx-vmimport/stuff
-  tag:
+  tagging:
     - arn:aws:ssm:us-east-1:123456789012:parameter/test
   permissions-management:
     - arn:aws:s3:::example-org-s3-access-logs

--- a/examples/input-dir/policy-zebu.yml
+++ b/examples/input-dir/policy-zebu.yml
@@ -1,7 +1,7 @@
 policy_with_crud_levels:
 - name: 'RoleNameWithCRUD'
   description: 'Why I need these privs'
-  arn: 'arn:aws:iam::123456789012:role/RiskyEC2'
+  role_arn: 'arn:aws:iam::123456789012:role/RiskyEC2'
   read:
     - arn:aws:s3:::example-org-sbx-vmimport
     - arn:aws:s3:::example-kinnaird
@@ -18,7 +18,7 @@ policy_with_crud_levels:
   list:
     - arn:aws:s3:::example-org-flow-logs
     - arn:aws:s3:::example-org-sbx-vmimport/stuff
-  tag:
+  tagging
     - arn:aws:ssm:us-east-1:123456789012:parameter/test
   permissions-management:
     - arn:aws:s3:::example-org-s3-access-logs

--- a/examples/library-usage/writing/write_policy_with_access_levels.py
+++ b/examples/library-usage/writing/write_policy_with_access_levels.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+from policy_sentry.shared.database import connect_db
+from policy_sentry.writing.template import get_crud_template_dict, get_actions_template_dict
+from policy_sentry.command.write_policy import write_policy_with_access_levels, write_policy_with_actions
+import json
+
+
+if __name__ == '__main__':
+    db_session = connect_db('bundled')
+    crud_template = get_crud_template_dict()
+    wildcard_actions_to_add = ["kms:createcustomkeystore", "cloudhsm:describeclusters"]
+
+    crud_template['policy_with_crud_levels'][0]['name'] = "MyPolicy"
+    crud_template['policy_with_crud_levels'][0]['description'] = "Description"
+    crud_template['policy_with_crud_levels'][0]['role_arn'] = "somearn"
+    crud_template['policy_with_crud_levels'][0]['read'].append(
+        "arn:aws:secretsmanager:us-east-1:123456789012:secret:mysecret")
+    crud_template['policy_with_crud_levels'][0]['write'].append(
+        "arn:aws:secretsmanager:us-east-1:123456789012:secret:mysecret")
+    crud_template['policy_with_crud_levels'][0]['list'].append("arn:aws:s3:::example-org-sbx-vmimport/stuff")
+    crud_template['policy_with_crud_levels'][0]['permissions-management'].append(
+        "arn:aws:kms:us-east-1:123456789012:key/123456")
+    crud_template['policy_with_crud_levels'][0]['wildcard'].extend(wildcard_actions_to_add)
+    crud_template['policy_with_crud_levels'][0]['tagging'].append("arn:aws:ssm:us-east-1:123456789012:parameter/test")
+
+    policy = write_policy_with_access_levels(db_session, crud_template, None)
+    print(json.dumps(policy, indent=4))
+
+"""
+Output:
+
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "MultMultNone",
+            "Effect": "Allow",
+            "Action": [
+                "kms:createcustomkeystore"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+            "Sid": "SecretsmanagerReadSecret",
+            "Effect": "Allow",
+            "Action": [
+                "secretsmanager:describesecret",
+                "secretsmanager:getresourcepolicy",
+                "secretsmanager:getsecretvalue",
+                "secretsmanager:listsecretversionids"
+            ],
+            "Resource": [
+                "arn:aws:secretsmanager:us-east-1:123456789012:secret:mysecret"
+            ]
+        },
+        {
+            "Sid": "SecretsmanagerWriteSecret",
+            "Effect": "Allow",
+            "Action": [
+                "secretsmanager:cancelrotatesecret",
+                "secretsmanager:deletesecret",
+                "secretsmanager:putsecretvalue",
+                "secretsmanager:restoresecret",
+                "secretsmanager:rotatesecret",
+                "secretsmanager:updatesecret",
+                "secretsmanager:updatesecretversionstage"
+            ],
+            "Resource": [
+                "arn:aws:secretsmanager:us-east-1:123456789012:secret:mysecret"
+            ]
+        },
+        {
+            "Sid": "KmsPermissionsmanagementKmskey",
+            "Effect": "Allow",
+            "Action": [
+                "kms:creategrant",
+                "kms:putkeypolicy",
+                "kms:retiregrant",
+                "kms:revokegrant"
+            ],
+            "Resource": [
+                "arn:aws:kms:us-east-1:123456789012:key/123456"
+            ]
+        }
+    ]
+}
+"""

--- a/examples/library-usage/writing/write_policy_with_actions.py
+++ b/examples/library-usage/writing/write_policy_with_actions.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+from policy_sentry.shared.database import connect_db
+from policy_sentry.writing.template import get_crud_template_dict, get_actions_template_dict
+from policy_sentry.command.write_policy import write_policy_with_access_levels, write_policy_with_actions
+import json
+
+
+if __name__ == '__main__':
+    db_session = connect_db('bundled')
+    actions_template = get_actions_template_dict()
+    print(actions_template)
+    actions_to_add = ['kms:CreateGrant', 'kms:CreateCustomKeyStore', 'ec2:AuthorizeSecurityGroupEgress',
+                      'ec2:AuthorizeSecurityGroupIngress']
+    actions_template['policy_with_actions'][0]['name'] = "MyPolicy"
+    actions_template['policy_with_actions'][0]['description'] = "Description"
+    actions_template['policy_with_actions'][0]['role_arn'] = "somearn"
+    actions_template['policy_with_actions'][0]['actions'].extend(actions_to_add)
+    policy = write_policy_with_actions(db_session, actions_template)
+    print(json.dumps(policy, indent=4))
+
+"""
+Output:
+
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "KmsPermissionsmanagementKmskey",
+            "Effect": "Allow",
+            "Action": [
+                "kms:creategrant"
+            ],
+            "Resource": [
+                "arn:${Partition}:kms:${Region}:${Account}:key/${KeyId}"
+            ]
+        },
+        {
+            "Sid": "Ec2WriteSecuritygroup",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:authorizesecuritygroupegress",
+                "ec2:authorizesecuritygroupingress"
+            ],
+            "Resource": [
+                "arn:${Partition}:ec2:${Region}:${Account}:security-group/${SecurityGroupId}"
+            ]
+        },
+        {
+            "Sid": "MultMultNone",
+            "Effect": "Allow",
+            "Action": [
+                "kms:createcustomkeystore",
+                "cloudhsm:describeclusters"
+            ],
+            "Resource": [
+                "*"
+            ]
+        }
+    ]
+}
+"""

--- a/examples/terraform/environments/iam-resources/files/example-role-jpwdp.yml.example
+++ b/examples/terraform/environments/iam-resources/files/example-role-jpwdp.yml.example
@@ -15,5 +15,5 @@ policy_with_crud_levels:
     - arn:aws:ec2:us-west-1:012345678910:vpc/vpc-0066a88d425956d10
   permissions-management:
     - arn:aws:ssm:us-west-1:012345678910:parameter/policy_sentry/test-jpwdp
-  tag:
+  tagging:
     - arn:aws:ec2:us-west-1:012345678910:vpc/vpc-0066a88d425956d10

--- a/examples/terraform/modules/generate-policy_sentry-yml/templates/vibranium-template.yml
+++ b/examples/terraform/modules/generate-policy_sentry-yml/templates/vibranium-template.yml
@@ -1,7 +1,7 @@
 policy_with_crud_levels:
 - name: ${policy_sentry_role_name}
   description: ${policy_sentry_role_description}
-  arn: ${policy_sentry_role_arn}
+  role_arn: ${policy_sentry_role_arn}
   write:
 ${policy_sentry_yaml_write}
   read:
@@ -10,5 +10,5 @@ ${policy_sentry_yaml_read}
 ${policy_sentry_yaml_list}
   permissions-management:
 ${policy_sentry_yaml_permissions_management}
-  tag:
+  tagging:
 ${policy_sentry_yaml_tag}

--- a/examples/yml/actions.yml
+++ b/examples/yml/actions.yml
@@ -2,7 +2,7 @@
 policy_with_actions:
 - name: 'RoleNameWithActions'
   description: 'Why I need these privs'
-  arn: 'arn:aws:iam::123456789102:role/RiskyEC2'
+  role_arn: 'arn:aws:iam::123456789102:role/RiskyEC2'
   actions:
   - kms:CreateGrant
   - kms:CreateCustomKeyStore

--- a/examples/yml/crud-with-wildcard.yml
+++ b/examples/yml/crud-with-wildcard.yml
@@ -1,7 +1,7 @@
 policy_with_crud_levels:
 - name: 'RoleNameWithCRUD'
   description: 'Why I need these privs'
-  arn: 'arn:aws:iam::123456789012:role/RiskyEC2'
+  role_arn: 'arn:aws:iam::123456789012:role/RiskyEC2'
 #  read:
 #    - arn:aws:s3:::example-org-sbx-vmimport/stuff
 #  write:
@@ -9,7 +9,7 @@ policy_with_crud_levels:
 #  list:
 #    - arn:aws:s3:::example-org-flow-logs
 #    - arn:aws:s3:::example-org-sbx-vmimport/stuff
-#  tag:
+#  tagging:
 #    - arn:aws:ssm:us-east-1:123456789012:parameter/test
   permissions-management:
     - arn:aws:s3:::example-org-s3-access-logs

--- a/examples/yml/crud.yml
+++ b/examples/yml/crud.yml
@@ -1,7 +1,7 @@
 policy_with_crud_levels:
 - name: 'RoleNameWithCRUD'
   description: 'Why I need these privs'
-  arn: 'arn:aws:iam::123456789012:role/RiskyEC2'
+  role_arn: 'arn:aws:iam::123456789012:role/RiskyEC2'
   read:
     - arn:aws:s3:::example-org-sbx-vmimport
     - arn:aws:s3:::example-kinnaird
@@ -18,7 +18,7 @@ policy_with_crud_levels:
   list:
     - arn:aws:s3:::example-org-flow-logs
     - arn:aws:s3:::example-org-sbx-vmimport/stuff
-  tag:
+  tagging:
     - arn:aws:ssm:us-east-1:123456789012:parameter/test
   permissions-management:
     - arn:aws:s3:::example-org-s3-access-logs

--- a/policy_sentry/bin/policy_sentry
+++ b/policy_sentry/bin/policy_sentry
@@ -2,7 +2,7 @@
 """
     policy_sentry is a tool for generating least-privilege IAM Policies.
 """
-__version__ = '0.6.6'
+__version__ = '0.6.7'
 import click
 from policy_sentry import command
 

--- a/policy_sentry/command/write_policy.py
+++ b/policy_sentry/command/write_policy.py
@@ -45,20 +45,22 @@ def print_policy(
     return policy
 
 
-def write_policy_with_access_levels(cfg, db_session, minimize_statement=False):
+def write_policy_with_access_levels(db_session, cfg, minimize_statement=None):
     """
     Writes an IAM policy given a dict containing Access Levels and ARNs.
     """
+    check_crud_schema(cfg)
     arn_action_group = ArnActionGroup()
     arn_dict = arn_action_group.process_resource_specific_acls(cfg, db_session)
     policy = print_policy(arn_dict, db_session, minimize_statement)
     return policy
 
 
-def write_policy_with_actions(cfg, db_session, minimize_statement=False):
+def write_policy_with_actions(db_session, cfg, minimize_statement=None):
     """
     Writes an IAM policy given a dict containing lists of actions.
     """
+    check_actions_schema(cfg)
     policy_with_actions = Roles()
     policy_with_actions.process_actions_config(cfg)
     supplied_actions = []
@@ -114,11 +116,9 @@ def write_policy(input_file, crud, minimize):
 
     # User supplies file containing resource-specific access levels
     if crud:
-        check_crud_schema(cfg)
-        policy = write_policy_with_access_levels(cfg, db_session, minimize)
+        policy = write_policy_with_access_levels(db_session, cfg, minimize)
     # User supplies file containing a list of IAM actions
     else:
-        check_actions_schema(cfg)
-        policy = write_policy_with_actions(cfg, db_session, minimize)
+        policy = write_policy_with_actions(db_session, cfg, minimize)
     print(json.dumps(policy, indent=4))
     return policy

--- a/policy_sentry/command/write_policy_dir.py
+++ b/policy_sentry/command/write_policy_dir.py
@@ -83,10 +83,10 @@ def write_policy_dir(input_dir, output_dir, crud, minimize):
         cfg = read_yaml_file(yaml_file)
         # User supplies file containing resource-specific access levels
         if crud:
-            policy = write_policy_with_access_levels(cfg, db_session, minimize)
+            policy = write_policy_with_access_levels(db_session, cfg, minimize)
         # User supplies file containing a list of IAM actions
         else:
-            policy = write_policy_with_actions(cfg, db_session, minimize)
+            policy = write_policy_with_actions(db_session, cfg, minimize)
         print("Writing policy for " + base_name + '\n')
 
         target_file = str(output_dir + '/' + base_name_no_extension + '.json')

--- a/policy_sentry/shared/data/links.yml
+++ b/policy_sentry/shared/data/links.yml
@@ -393,7 +393,7 @@ swf:
 - list_amazonsimpleworkflowservice.partial.html
 synthetics:
 - list_amazoncloudwatchsynthetics.partial.html
-tag:
+tagging:
 - list_amazonresourcegrouptaggingapi.partial.html
 textract:
 - list_amazontextract.partial.html

--- a/policy_sentry/writing/roles.py
+++ b/policy_sentry/writing/roles.py
@@ -39,7 +39,7 @@ class Roles:
                             [
                                 principal['name'],
                                 principal['description'],
-                                principal['arn'],
+                                principal['role_arn'],
                                 principal['actions'],
                             ]
                         )

--- a/policy_sentry/writing/template.py
+++ b/policy_sentry/writing/template.py
@@ -7,7 +7,7 @@ ACTIONS_TEMPLATE = '''# Generate my policy when I know the Actions
 policy_with_actions:
 - name: {{ name }}
   description: ''
-  arn: ''
+  role_arn: ''
   actions:
   - ''
 '''
@@ -16,7 +16,7 @@ CRUD_TEMPLATE = '''# Generate my policy when I know the access levels and ARNs
 policy_with_crud_levels:
 - name: {{ name }}
   description: ''
-  arn: ''
+  role_arn: ''
   # Insert ARNs under each access level below
   # If you do not need to use certain access levels, delete them.
   read:
@@ -25,7 +25,7 @@ policy_with_crud_levels:
     - ''
   list:
     - ''
-  tag:
+  tagging:
     - ''
   permissions-management:
     - ''
@@ -34,6 +34,33 @@ policy_with_crud_levels:
   wildcard:
     - ''
 '''
+
+CRUD_TEMPLATE_DICT = {
+    'policy_with_crud_levels': [
+        {
+            'name': '',
+            'description': '',
+            'role_arn': '',
+            'read': [],
+            'write': [],
+            'list': [],
+            'tagging': [],
+            'permissions-management': [],
+            'wildcard': [],
+        }
+    ]
+}
+
+ACTIONS_TEMPLATE_DICT = {
+    'policy_with_actions': [
+        {
+            'name': '',
+            'description': '',
+            'role_arn': '',
+            'actions': [],
+        }
+    ]
+}
 
 
 def create_crud_template(name):
@@ -48,3 +75,13 @@ def create_actions_template(name):
     template = Template(ACTIONS_TEMPLATE)
     msg = template.render(name=name)
     return msg
+
+
+def get_crud_template_dict():
+    """Generate the CRUD template in dict format"""
+    return CRUD_TEMPLATE_DICT
+
+
+def get_actions_template_dict():
+    """Get the Actions template in dict format."""
+    return ACTIONS_TEMPLATE_DICT

--- a/policy_sentry/writing/validate.py
+++ b/policy_sentry/writing/validate.py
@@ -23,12 +23,12 @@ CRUD_SCHEMA = Schema({
         {
             'name': And(Use(str)),
             'description': And(Use(str)),
-            'arn': And(Use(str)),
+            'role_arn': And(Use(str)),
             Optional('read'): [str],
             Optional('write'): [str],
             Optional('list'): [str],
             Optional('permissions-management'): [str],
-            Optional('tag'): [str],
+            Optional('tagging'): [str],
             Optional('wildcard'): [str],
 
         }
@@ -40,7 +40,7 @@ ACTIONS_SCHEMA = Schema({
         {
             'name': And(Use(str)),
             'description': And(Use(str)),
-            'arn': And(Use(str)),
+            'role_arn': And(Use(str)),
             'actions': And([str]),
         }
     ]

--- a/test/test_template.py
+++ b/test/test_template.py
@@ -8,7 +8,7 @@ class TemplateTestCase(unittest.TestCase):
 policy_with_actions:
 - name: myrole
   description: ''
-  arn: ''
+  role_arn: ''
   actions:
   - ''"""
         actions_template = create_actions_template("myrole")
@@ -19,7 +19,7 @@ policy_with_actions:
 policy_with_crud_levels:
 - name: myrole
   description: ''
-  arn: ''
+  role_arn: ''
   # Insert ARNs under each access level below
   # If you do not need to use certain access levels, delete them.
   read:
@@ -28,7 +28,7 @@ policy_with_crud_levels:
     - ''
   list:
     - ''
-  tag:
+  tagging:
     - ''
   permissions-management:
     - ''

--- a/test/test_template_validation.py
+++ b/test/test_template_validation.py
@@ -6,7 +6,7 @@ valid_cfg_for_crud = {
         {
             "name": "RoleNameWithCRUD",
             "description": "Why I need these privs",
-            "arn": "arn:aws:iam::123456789012:role/MyRole",
+            "role_arn": "arn:aws:iam::123456789012:role/MyRole",
             "read": [
                 "arn:aws:s3:::example-org-sbx-vmimport",
             ],
@@ -17,7 +17,7 @@ valid_cfg_for_crud = {
                 "arn:aws:s3:::example-org-flow-logs",
                 "arn:aws:s3:::example-org-sbx-vmimport/stuff"
             ],
-            "tag": [
+            "tagging": [
                 "arn:aws:ssm:us-east-1:123456789012:parameter/test"
             ],
             "permissions-management": [
@@ -35,7 +35,7 @@ valid_cfg_for_actions = {
         {
             "name": "RoleNameWithActions",
             "description": "Why I need these privs",
-            "arn": "arn:aws:iam::123456789102:role/MyRole",
+            "role_arn": "arn:aws:iam::123456789102:role/MyRole",
             "actions": [
                 "kms:CreateGrant",
                 "kms:CreateCustomKeyStore",
@@ -51,7 +51,7 @@ valid_crud_with_one_item_only = {
         {
             "name": "RoleNameWithCRUD",
             "description": "Why I need these privs",
-            "arn": "arn:aws:iam::123456789012:role/MyRole",
+            "role_arn": "arn:aws:iam::123456789012:role/MyRole",
             "read": [
                 "arn:aws:s3:::example-org-sbx-vmimport",
             ],
@@ -64,7 +64,7 @@ invalid_crud_with_mispelled_category = {
         {
             "name": "RoleNameWithCRUD",
             "description": "Why I need these privs",
-            "arn": "arn:aws:iam::123456789012:role/MyRole",
+            "role_arn": "arn:aws:iam::123456789012:role/MyRole",
             "reed": [
                 "arn:aws:s3:::example-org-sbx-vmimport",
             ],

--- a/test/test_write_policy.py
+++ b/test/test_write_policy.py
@@ -1,10 +1,10 @@
 import unittest
 import json
-from policy_sentry.shared.database import connect_db
-from policy_sentry.writing.policy import ArnActionGroup
 from policy_sentry.command.write_policy import print_policy
 from policy_sentry.querying.actions import get_dependent_actions
 from policy_sentry.shared.constants import DATABASE_FILE_PATH
+from policy_sentry.shared.database import connect_db
+from policy_sentry.writing.policy import ArnActionGroup
 
 db_session = connect_db(DATABASE_FILE_PATH)
 
@@ -150,7 +150,7 @@ class WritePolicyPreventWildcardEscalation(unittest.TestCase):
                 {
                     'name': 'RoleNameWithCRUD',
                     'description': 'Why I need these privs',
-                    'arn': 'arn:aws:iam::123456789012:role/RiskyEC2',
+                    'role_arn': 'arn:aws:iam::123456789012:role/RiskyEC2',
                     'permissions-management': [
                         'arn:aws:s3:::example-org-s3-access-logs'
                     ],

--- a/test/test_write_policy_library_usage.py
+++ b/test/test_write_policy_library_usage.py
@@ -1,0 +1,140 @@
+import unittest
+import json
+from policy_sentry.shared.database import connect_db
+from policy_sentry.writing.template import get_crud_template_dict, get_actions_template_dict
+from policy_sentry.command.write_policy import write_policy_with_access_levels, write_policy_with_actions
+
+desired_crud_policy = {
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "MultMultNone",
+            "Effect": "Allow",
+            "Action": [
+                "kms:createcustomkeystore"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+            "Sid": "SecretsmanagerReadSecret",
+            "Effect": "Allow",
+            "Action": [
+                "secretsmanager:describesecret",
+                "secretsmanager:getresourcepolicy",
+                "secretsmanager:getsecretvalue",
+                "secretsmanager:listsecretversionids"
+            ],
+            "Resource": [
+                "arn:aws:secretsmanager:us-east-1:123456789012:secret:mysecret"
+            ]
+        },
+        {
+            "Sid": "SecretsmanagerWriteSecret",
+            "Effect": "Allow",
+            "Action": [
+                "secretsmanager:cancelrotatesecret",
+                "secretsmanager:deletesecret",
+                "secretsmanager:putsecretvalue",
+                "secretsmanager:restoresecret",
+                "secretsmanager:rotatesecret",
+                "secretsmanager:updatesecret",
+                "secretsmanager:updatesecretversionstage"
+            ],
+            "Resource": [
+                "arn:aws:secretsmanager:us-east-1:123456789012:secret:mysecret"
+            ]
+        },
+        {
+            "Sid": "KmsPermissionsmanagementKmskey",
+            "Effect": "Allow",
+            "Action": [
+                "kms:creategrant",
+                "kms:putkeypolicy",
+                "kms:retiregrant",
+                "kms:revokegrant"
+            ],
+            "Resource": [
+                "arn:aws:kms:us-east-1:123456789012:key/123456"
+            ]
+        }
+    ]
+}
+
+desired_actions_policy = {
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "KmsPermissionsmanagementKmskey",
+            "Effect": "Allow",
+            "Action": [
+                "kms:creategrant"
+            ],
+            "Resource": [
+                "arn:${Partition}:kms:${Region}:${Account}:key/${KeyId}"
+            ]
+        },
+        {
+            "Sid": "Ec2WriteSecuritygroup",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:authorizesecuritygroupegress",
+                "ec2:authorizesecuritygroupingress"
+            ],
+            "Resource": [
+                "arn:${Partition}:ec2:${Region}:${Account}:security-group/${SecurityGroupId}"
+            ]
+        },
+        {
+            "Sid": "MultMultNone",
+            "Effect": "Allow",
+            "Action": [
+                "kms:createcustomkeystore",
+                "cloudhsm:describeclusters"
+            ],
+            "Resource": [
+                "*"
+            ]
+        }
+    ]
+}
+
+
+class WritePolicyWithLibraryOnly(unittest.TestCase):
+
+    def test_write_actions_policy_with_library_only(self):
+        """test_write_actions_policy_with_library_only: Write an actions mode policy without using the command line at all (library only)"""
+        db_session = connect_db('bundled')
+        actions_template = get_actions_template_dict()
+        print(actions_template)
+        actions_to_add = ['kms:CreateGrant', 'kms:CreateCustomKeyStore', 'ec2:AuthorizeSecurityGroupEgress', 'ec2:AuthorizeSecurityGroupIngress']
+        actions_template['policy_with_actions'][0]['name'] = "MyPolicy"
+        actions_template['policy_with_actions'][0]['description'] = "Description"
+        actions_template['policy_with_actions'][0]['role_arn'] = "somearn"
+        actions_template['policy_with_actions'][0]['actions'].extend(actions_to_add)
+        # Modify it
+        policy = write_policy_with_actions(db_session, actions_template)
+        # print(json.dumps(policy, indent=4))
+        self.maxDiff = None
+        self.assertDictEqual(desired_actions_policy, policy)
+
+    def test_write_crud_policy_with_library_only(self):
+        """test_write_crud_policy_with_library_only: Write an actions mode policy without using the command line at all (library only)"""
+        db_session = connect_db('bundled')
+        crud_template = get_crud_template_dict()
+        wildcard_actions_to_add = ["kms:createcustomkeystore", "cloudhsm:describeclusters"]
+        print(crud_template)
+        crud_template['policy_with_crud_levels'][0]['name'] = "MyPolicy"
+        crud_template['policy_with_crud_levels'][0]['description'] = "Description"
+        crud_template['policy_with_crud_levels'][0]['role_arn'] = "somearn"
+        crud_template['policy_with_crud_levels'][0]['read'].append("arn:aws:secretsmanager:us-east-1:123456789012:secret:mysecret")
+        crud_template['policy_with_crud_levels'][0]['write'].append("arn:aws:secretsmanager:us-east-1:123456789012:secret:mysecret")
+        crud_template['policy_with_crud_levels'][0]['list'].append("arn:aws:s3:::example-org-sbx-vmimport/stuff")
+        crud_template['policy_with_crud_levels'][0]['permissions-management'].append("arn:aws:kms:us-east-1:123456789012:key/123456")
+        crud_template['policy_with_crud_levels'][0]['wildcard'].extend(wildcard_actions_to_add)
+        crud_template['policy_with_crud_levels'][0]['tagging'].append("arn:aws:ssm:us-east-1:123456789012:parameter/test")
+        # Modify it
+        policy = write_policy_with_access_levels(db_session, crud_template, None)
+        # print(json.dumps(policy, indent=4))
+        self.assertDictEqual(desired_crud_policy, policy)

--- a/test/test_yaml.py
+++ b/test/test_yaml.py
@@ -12,7 +12,7 @@ valid_cfg_for_crud = {
         {
             "name": "RoleNameWithCRUD",
             "description": "Why I need these privs",
-            "arn": "arn:aws:iam::123456789012:role/RiskyEC2",
+            "role_arn": "arn:aws:iam::123456789012:role/RiskyEC2",
             "read": [
                 "arn:aws:s3:::example-org-sbx-vmimport",
                 "arn:aws:s3:::example-kinnaird",
@@ -32,7 +32,7 @@ valid_cfg_for_crud = {
                 "arn:aws:s3:::example-org-flow-logs",
                 "arn:aws:s3:::example-org-sbx-vmimport/stuff"
             ],
-            "tag": [
+            "tagging": [
                 "arn:aws:ssm:us-east-1:123456789012:parameter/test"
             ],
             "permissions-management": [
@@ -47,7 +47,7 @@ valid_cfg_for_actions = {
         {
             "name": "RoleNameWithActions",
             "description": "Why I need these privs",
-            "arn": "arn:aws:iam::123456789102:role/RiskyEC2",
+            "role_arn": "arn:aws:iam::123456789102:role/RiskyEC2",
             "actions": [
                 "kms:CreateGrant",
                 "kms:CreateCustomKeyStore",
@@ -72,7 +72,7 @@ class YamlValidationOverallTestCase(unittest.TestCase):
     #             {
     #                 "name": "RoleNameWithActions",
     #                 "description": "Why I need these privs",
-    #                 "arn": "arn:aws:iam::123456789102:role/RiskyEC2",
+    #                 "role_arn": "arn:aws:iam::123456789102:role/RiskyEC2",
     #                 "actions": [
     #                     "kms:CreateGrant",
     #                     "kms:CreateCustomKeyStore",
@@ -83,7 +83,7 @@ class YamlValidationOverallTestCase(unittest.TestCase):
     #             {
     #                 "name": "DuplicateRoleNameWithActions",
     #                 "description": "Why I need these privs",
-    #                 "arn": "arn:aws:iam::123456789102:role/RiskyEC2",
+    #                 "role_arn": "arn:aws:iam::123456789102:role/RiskyEC2",
     #                 "actions": [
     #                     "kms:CreateGrant",
     #                     "kms:CreateCustomKeyStore",
@@ -107,7 +107,7 @@ class YamlValidationOverallTestCase(unittest.TestCase):
     #             {
     #                 "name": "RoleNameWithActions",
     #                 "description": "Why I need these privs",
-    #                 "arn": "arn:aws:iam::123456789102:role/RiskyEC2",
+    #                 "role_arn": "arn:aws:iam::123456789102:role/RiskyEC2",
     #                 "actions": [
     #                     "kms:CreateGrant",
     #                     "kms:CreateCustomKeyStore",
@@ -120,7 +120,7 @@ class YamlValidationOverallTestCase(unittest.TestCase):
     #             {
     #                 "name": "DuplicateRoleNameWithActions",
     #                 "description": "Why I need these privs",
-    #                 "arn": "arn:aws:iam::123456789102:role/RiskyEC2",
+    #                 "role_arn": "arn:aws:iam::123456789102:role/RiskyEC2",
     #                 "actions": [
     #                     "kms:CreateGrant",
     #                     "kms:CreateCustomKeyStore",
@@ -146,7 +146,7 @@ class YamlValidationOverallTestCase(unittest.TestCase):
     #                     "arn:aws:s3:::example-org-flow-logs",
     #                     "arn:aws:s3:::example-org-sbx-vmimport/stuff"
     #                 ],
-    #                 "tag": [
+    #                 "tagging": [
     #                     "arn:aws:ssm:us-east-1:123456789012:parameter/test"
     #                 ],
     #                 "permissions-management": [
@@ -189,7 +189,7 @@ class YamlValidationOverallTestCase(unittest.TestCase):
             "policy_with_actions": [
                 {
                     "description": "Why I need these privs",
-                    "arn": "arn:aws:iam::123456789102:role/RiskyEC2",
+                    "role_arn": "arn:aws:iam::123456789102:role/RiskyEC2",
                     "actions": [
                         "kms:CreateGrant",
                         "kms:CreateCustomKeyStore",
@@ -199,8 +199,8 @@ class YamlValidationOverallTestCase(unittest.TestCase):
                 }
             ]
         }
-        with self.assertRaises(SystemExit):
-            policy = write_policy_with_actions(cfg_with_missing_name, db_session)
+        with self.assertRaises(Exception):
+            policy = write_policy_with_actions(db_session, cfg_with_missing_name)
 
 
     def test_actions_missing_description(self):
@@ -212,7 +212,7 @@ class YamlValidationOverallTestCase(unittest.TestCase):
             "policy_with_actions": [
                 {
                     "name": "RoleNameWithActions",
-                    "arn": "arn:aws:iam::123456789102:role/RiskyEC2",
+                    "role_arn": "arn:aws:iam::123456789102:role/RiskyEC2",
                     "actions": [
                         "kms:CreateGrant",
                         "kms:CreateCustomKeyStore",
@@ -222,8 +222,8 @@ class YamlValidationOverallTestCase(unittest.TestCase):
                 }
             ]
         }
-        with self.assertRaises(SystemExit):
-            policy = write_policy_with_actions(cfg_with_missing_description, db_session)
+        with self.assertRaises(Exception):
+            policy = write_policy_with_actions(db_session, cfg_with_missing_description)
 
     def test_actions_missing_arn(self):
         """
@@ -244,8 +244,8 @@ class YamlValidationOverallTestCase(unittest.TestCase):
                 }
             ]
         }
-        with self.assertRaises(SystemExit):
-            policy = write_policy_with_actions(cfg_with_missing_actions, db_session)
+        with self.assertRaises(Exception):
+            policy = write_policy_with_actions(db_session, cfg_with_missing_actions)
 
 
 class YamlValidationCrudTestCase(unittest.TestCase):
@@ -263,7 +263,7 @@ class YamlValidationCrudTestCase(unittest.TestCase):
                 {
                     "name": "RoleNameWithCRUD",
                     "description": "Why I need these privs",
-                    "arn": "arn:aws:iam::123456789012:role/RiskyEC2",
+                    "role_arn": "arn:aws:iam::123456789012:role/RiskyEC2",
                     "read": [
                         "arn:aws:ssm:us-east-1:123456789012:parameter/test",
                     ],
@@ -279,7 +279,7 @@ class YamlValidationCrudTestCase(unittest.TestCase):
         }
         self.maxDiff = None
 
-        result = write_policy_with_access_levels(crud_file_input, db_session)
+        result = write_policy_with_access_levels(db_session, crud_file_input)
         print(json.dumps(result, indent=4))
 
     def test_empty_strings_in_access_level_categories(self):
@@ -292,7 +292,7 @@ class YamlValidationCrudTestCase(unittest.TestCase):
                 {
                     "name": "RoleNameWithCRUD",
                     "description": "Why I need these privs",
-                    "arn": "arn:aws:iam::123456789012:role/RiskyEC2",
+                    "role_arn": "arn:aws:iam::123456789012:role/RiskyEC2",
                     "read": [
                         "arn:aws:ssm:us-east-1:123456789012:parameter/test",
                     ],
@@ -303,7 +303,7 @@ class YamlValidationCrudTestCase(unittest.TestCase):
                     "list": [
                         "arn:aws:ssm:us-east-1:123456789012:parameter/test",
                     ],
-                    "tag": [
+                    "tagging": [
                         ""
                     ],
                     "permissions-management": [
@@ -313,7 +313,7 @@ class YamlValidationCrudTestCase(unittest.TestCase):
             ]
         }
         with self.assertRaises(SystemExit):
-            result = write_policy_with_access_levels(crud_file_input, db_session)
+            result = write_policy_with_access_levels(db_session, crud_file_input)
             print(json.dumps(result, indent=4))
 
 
@@ -329,10 +329,10 @@ class YamlValidationActionsTestCase(unittest.TestCase):
                 {
                     "name": "RoleNameWithActions",
                     "description": "Why I need these privs",
-                    "arn": "arn:aws:iam::123456789102:role/RiskyEC2",
+                    "role_arn": "arn:aws:iam::123456789102:role/RiskyEC2",
                 }
             ]
         }
-        with self.assertRaises(SystemExit):
-            policy = write_policy_with_actions(cfg_with_missing_actions, db_session)
+        with self.assertRaises(Exception):
+            policy = write_policy_with_actions(db_session, cfg_with_missing_actions)
 

--- a/utils/run_tests.sh
+++ b/utils/run_tests.sh
@@ -17,3 +17,5 @@ pipenv run invoke integration.analyze-policy
 pipenv run invoke integration.query
 pipenv run invoke integration.write-policy
 pipenv run invoke test.security
+pipenv run invoke docs.remove-html-files
+pipenv run invoke docs.make-html


### PR DESCRIPTION
* 0.6.7 release to avoid issues with breaking changes
* Template:
  - `arn` is now `role_arn` to avoid confusion when writing templates
  - `tag` is now `tagging` to avoid inconsistency when writing templates
* `command/write_policy/write_policy_with_actions` and `command/write_policy/write_policy_with_access_levels` can be called directly.
* `writing/template/` now exposes `get_crud_template_dict` and `get_actions_template_dict` so developers can create the templates by calling the library. We might add on additional ones so they can just pass in lists without having to know the format, but not right now. They can pass that into `write_policy_with_actions` and `write_policy_with_access_levels`
* Added examples for the above in the docs