### PR TITLE
Fix string literal comparison error with python 3.8

### DIFF
--- a/policy_sentry/util/policy_files.py
+++ b/policy_sentry/util/policy_files.py
@@ -13,8 +13,8 @@ def get_actions_from_policy(data):
             # Statement must be a dict if it's a single statement. Otherwise it will be a list of statements
             if isinstance(data['Statement'], dict):
                 # We only want to evaluate policies that have Effect = "Allow"
-                # pylint: disable=no-else-continue, literal-comparison
-                if data['Statement']['Effect'] is 'Deny':
+                # pylint: disable=no-else-continue
+                if data['Statement']['Effect'] == 'Deny':
                     continue
                 else:
                     try:

--- a/policy_sentry/writing/minimize.py
+++ b/policy_sentry/writing/minimize.py
@@ -80,8 +80,7 @@ def minimize_statement_actions(desired_actions, all_actions, minchars=None):  # 
                 continue
             # If the action name is not empty
             if prefix not in denied_prefixes:
-                # pylint: disable=literal-comparison
-                if permission is not '':
+                if permission != '':
                     if prefix not in desired_actions:
                         prefix = "{}*".format(prefix)
                     minimized_actions.add(prefix)


### PR DESCRIPTION
Fixing string literal comparison issue so the error doesn't show up in Travis like it did in the build for #86 

Merging that one after this