### PR TITLE
Quick fix: issue where Tagging was not being recognized in the write-policy YML templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 _notes/*
 tmp/*
-tmp.yml
+tmp*
 *.csv
 state.tf
 report.json

--- a/policy_sentry/bin/policy_sentry
+++ b/policy_sentry/bin/policy_sentry
@@ -2,7 +2,7 @@
 """
     policy_sentry is a tool for generating least-privilege IAM Policies.
 """
-__version__ = '0.6.9'
+__version__ = '0.6.10'
 import click
 from policy_sentry import command
 

--- a/policy_sentry/writing/policy.py
+++ b/policy_sentry/writing/policy.py
@@ -126,10 +126,10 @@ class ArnActionGroup:
                                     db_session,
                                     principal['permissions-management'],
                                     "Permissions management")
-                        if 'tag' in principal.keys():
-                            if principal['tag'] is not None:
+                        if 'tagging' in principal.keys():
+                            if principal['tagging'] is not None:
                                 self.add(
-                                    db_session, principal['tag'], "Tagging")
+                                    db_session, principal['tagging'], "Tagging")
 
         # except KeyError as e:
         #     print("Yaml file is missing this block: " + e.args[0])

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -1,4 +1,5 @@
 import unittest
+import json
 from policy_sentry.shared.constants import DATABASE_FILE_PATH
 from policy_sentry.shared.database import connect_db
 from policy_sentry.querying.actions import get_actions_for_service, get_action_data, \
@@ -105,25 +106,26 @@ class QueryTestCase(unittest.TestCase):
     def test_get_action_data(self):
         """test_get_action_data: Tests function that gets details on a specific IAM Action."""
         desired_output = {
-            'ram': [
+            "ram": [
                 {
-                    'action': 'ram:createresourceshare',
-                    'description': 'Create resource share with provided resource(s) and/or principal(s)',
-                    'access_level': 'Permissions management',
-                    'resource_arn_format': '*',
-                    'condition_keys': [
-                        'aws:RequestTag/${TagKey}',
-                        'aws:TagKeys',
-                        'ram:RequestedResourceType',
-                        'ram:ResourceArn',
-                        'ram:RequestedAllowsExternalPrincipals',
-                        'ram:Principal'
+                    "action": "ram:createresourceshare",
+                    "description": "Create resource share with provided resource(s) and/or principal(s)",
+                    "access_level": "Permissions management",
+                    "resource_arn_format": "*",
+                    "condition_keys": [
+                        "aws:RequestTag/${TagKey}",
+                        "aws:TagKeys",
+                        "ram:RequestedResourceType",
+                        "ram:ResourceArn",
+                        "ram:RequestedAllowsExternalPrincipals",
+                        "ram:Principal"
                     ],
-                    'dependent_actions': None
+                    "dependent_actions": None
                 }
             ]
         }
         output = get_action_data(db_session, 'ram', 'createresourceshare')
+        print(json.dumps(output, indent=4))
         self.maxDiff = None
         self.assertDictEqual(desired_output, output)
 

--- a/test/test_write_policy_library_usage.py
+++ b/test/test_write_policy_library_usage.py
@@ -58,6 +58,17 @@ desired_crud_policy = {
             "Resource": [
                 "arn:aws:kms:us-east-1:123456789012:key/123456"
             ]
+        },
+        {
+            "Sid": "SsmTaggingParameter",
+            "Effect": "Allow",
+            "Resource": [
+                "arn:aws:ssm:us-east-1:123456789012:parameter/test"
+            ],
+            "Action": [
+                "ssm:addtagstoresource",
+                "ssm:removetagsfromresource",
+            ],
         }
     ]
 }
@@ -137,4 +148,5 @@ class WritePolicyWithLibraryOnly(unittest.TestCase):
         # Modify it
         policy = write_policy_with_access_levels(db_session, crud_template, None)
         # print(json.dumps(policy, indent=4))
+        self.maxDiff = None
         self.assertDictEqual(desired_crud_policy, policy)


### PR DESCRIPTION
If you specified "tagging" in your YML file, the write-policy command was ignoring it. This fixes that.