### PR TITLE
Initialize command finishes instantly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
-# 0.6.9 (2020-01-24)
+# 0.6.11 (2020-01-28)
+### Changed
+* Now you can skip the long wait under the `initialize` command - the initialize command finishes instantly. To rebuild the database, run `initialize --build`, or to build it with the latest AWS docs, use `initialize --fetch`. Fixes #101
+* Documentation updates. Fixes #102
+
+# 0.6.10 (2020-01-24)
+### Changed
+* writing: In the last version, if you specified "tagging" in your YML file, the write-policy command was ignoring it. This fixes that. #100
+
+## 0.6.9 (2020-01-24)
 ### Added
 * database: Fixes #51 - Give the user an error when the database file does not exist (in `connect_db` function). Except for the case of the initialize function.
 * query: The `query` command now supports querying for wildcard only actions at an access level per service. For example, the only wildcard-only action under S3 at the Permissions management access level is `s3:PutAccountPublicAccessBlock`

--- a/README.md
+++ b/README.md
@@ -9,7 +9,24 @@
 
 IAM Least Privilege Policy Generator, auditor, and analysis database.
 
-## Wiki
+- [Documentation](#documentation)
+- [Overview](#overview)
+  * [Authoring Secure IAM Policies](#authoring-secure-iam-policies)
+- [Quickstart](#quickstart)
+    + [Installation](#installation)
+    + [Shell completion](#shell-completion)
+  * [Initialization](#initialization)
+  * [Policy Writing cheat sheet](#policy-writing-cheat-sheet)
+  * [IAM Database Query Cheat Sheet](#iam-database-query-cheat-sheet)
+  * [Policy Analysis Cheat Sheet](#policy-analysis-cheat-sheet)
+- [Commands](#commands)
+  * [Usage](#usage)
+  * [Library usage](#library-usage)
+  * [Docker](#docker)
+  * [Updating the AWS HTML files](#updating-the-aws-html-files)
+- [References](#references)
+
+## Documentation
 
 For walkthroughs and full documentation, please visit the [project on ReadTheDocs](https://policy-sentry.readthedocs.io/en/latest/index.html).
 
@@ -72,7 +89,21 @@ How do we accomplish this? Well, Policy Sentry leverages the AWS documentation o
   </tr>
 </table>
 
-Policy Sentry aggregates all of that documentation into a single database and uses that database to generate policies according to actions, resources, and access levels. To generate a policy according to resources and access levels, start by creating a template with this command so you can just fill out the ARNs:
+Policy Sentry aggregates all of that documentation into a single database and uses that database to generate policies according to actions, resources, and access levels.
+
+To get started, install Policy Sentry:
+
+```bash
+pip3 install --user policy_sentry
+```
+
+Then initialize the IAM database:
+
+```bash
+policy_sentry initialize
+```
+
+To generate a policy according to resources and access levels, start by creating a template with this command so you can just fill out the ARNs:
 
 ```bash
 policy_sentry create-template --name myRole --output-file crud.yml --template-type crud
@@ -83,8 +114,8 @@ It will generate a file like this:
 ```yaml
 policy_with_crud_levels:
 - name: myRole
-  description: ''
-  role_arn: ''
+  description: '' # For human auditability
+  role_arn: '' # For human auditability
   # Insert ARNs under each access level below
   # If you do not need to use certain access levels, delete them.
   read:

--- a/docs/introduction/home.rst
+++ b/docs/introduction/home.rst
@@ -46,7 +46,19 @@ How do we accomplish this? Well, Policy Sentry leverages the AWS documentation o
 | secretsmanager:TagResource       | Tagging                | secret             |
 +----------------------------------+------------------------+--------------------+
 
-Policy Sentry aggregates all of that documentation into a single database and uses that database to generate policies according to actions, resources, and access levels. To generate a policy according to resources and access levels, start by creating a template with this command so you can just fill out the ARNs:
+Policy Sentry aggregates all of that documentation into a single database and uses that database to generate policies according to actions, resources, and access levels.
+
+To get started, install Policy Sentry:
+
+.. code-block:: bash
+   pip3 install --user policy_sentry
+
+Then initialize the IAM database:
+
+.. code-block:: bash
+   policy_sentry initialize
+
+To generate a policy according to resources and access levels, start by creating a template with this command so you can just fill out the ARNs:
 
 .. code-block:: bash
 

--- a/docs/user-guide/initialize.rst
+++ b/docs/user-guide/initialize.rst
@@ -13,7 +13,7 @@ Options
 * ``--access-level-overrides-file`` (Optional): Path to your own custom access level overrides file, used to override the Access Levels per action provided by AWS docs. The default one is `here <https://github.com/salesforce/policy_sentry/blob/master/policy_sentry/shared/data/access-level-overrides.yml>`__.
 * ``--fetch`` (Optional):  Specify this flag to fetch the HTML Docs directly from the AWS website. This will be helpful if the docs in the Git repository are behind the live docs and you need to use the latest version of the docs right now.
 
-*  ``--fetch`` (Optional) Specify this flag to fetch the HTML Docs directly from the AWS website. This will be helpful if the docs in the Git repository are behind the live docs and you need to use the latest version of the docs right now.
+*  ``--build`` (Optional) Build the SQLite database from the HTML files rather than copying the SQLite database file from the python package. Defaults to false.
 
 
 Usage
@@ -27,6 +27,9 @@ Usage
     # Fetch the most recent version of the AWS documentation so you can experiment with new services.
     # This can be helpful in case the AWS HTML files in the Python package are outdated, even if it is a week old
     policy_sentry initialize --fetch
+
+    # Build the database file from the HTML files rather than using the bundled binary.
+    policy_sentry initialize --build
 
     # Initialize the database with a custom Access Level Overrides file
 

--- a/policy_sentry/bin/policy_sentry
+++ b/policy_sentry/bin/policy_sentry
@@ -2,7 +2,7 @@
 """
     policy_sentry is a tool for generating least-privilege IAM Policies.
 """
-__version__ = '0.6.10'
+__version__ = '0.6.11'
 import click
 from policy_sentry import command
 

--- a/policy_sentry/command/initialize.py
+++ b/policy_sentry/command/initialize.py
@@ -2,6 +2,7 @@
 Create the Policy Sentry config folder (~/.policy_sentry/) and the contents within
 Create the SQLite database and fill it with the tables scraped from the AWS Docs
 """
+import shutil
 import click
 from policy_sentry.configuration.access_level_overrides import create_default_overrides_file
 from policy_sentry.configuration.analysis import create_default_report_config_file
@@ -11,7 +12,8 @@ from policy_sentry.querying.all import get_all_service_prefixes
 from policy_sentry.scraping.awsdocs import update_html_docs_directory, get_list_of_service_prefixes_from_links_file, \
     create_service_links_mapping_file
 from policy_sentry.shared.database import connect_db, create_database
-from policy_sentry.shared.constants import HOME, CONFIG_DIRECTORY, HTML_DIRECTORY_PATH, LINKS_YML_FILE_LOCAL
+from policy_sentry.shared.constants import HOME, CONFIG_DIRECTORY, HTML_DIRECTORY_PATH, LINKS_YML_FILE_LOCAL, \
+    BUNDLED_DATABASE_FILE_PATH
 
 
 @click.command(
@@ -21,7 +23,6 @@ from policy_sentry.shared.constants import HOME, CONFIG_DIRECTORY, HTML_DIRECTOR
     '--access-level-overrides-file',
     type=str,
     required=False,
-    default=HOME + CONFIG_DIRECTORY + 'access-level-overrides.yml',
     help='Path to access level overrides file, used to override the Access Levels per action provided by AWS docs'
 )
 @click.option(
@@ -33,12 +34,23 @@ from policy_sentry.shared.constants import HOME, CONFIG_DIRECTORY, HTML_DIRECTOR
          'in the Git repository are behind the live docs and you need to use the latest version of the docs right '
          'now.'
 )
-def initialize(access_level_overrides_file, fetch):
+@click.option(
+    '--build',
+    is_flag=True,
+    required=False,
+    default=False,
+    help='Build the SQLite database from the HTML files rather than copying the SQLite database file from '
+         'the python package. Defaults to false'
+)
+def initialize(access_level_overrides_file, fetch, build):
     """
-    Create a local database to store AWS IAM information, which can be used to generate IAM policies and analyze them
-    for least privilege.
+    Initialize the local database to store AWS IAM information, which can be used to generate IAM policies, and for
+    querying the database.
     """
-
+    if not access_level_overrides_file:
+        overrides_file = HOME + CONFIG_DIRECTORY + 'access-level-overrides.yml'
+    else:
+        overrides_file = access_level_overrides_file
     # Create the config directory
     database_path = create_policy_sentry_config_directory()
 
@@ -59,7 +71,15 @@ def initialize(access_level_overrides_file, fetch):
     # analyze_iam_policy
     create_default_report_config_file()
 
-    # If the user specifies fetch, wget the AWS IAM Actions, Resources and Condition Keys pages and store them locally.
+    if not build and not fetch:
+        # copy from the bundled database location to the destination path
+        shutil.copy(BUNDLED_DATABASE_FILE_PATH, database_path)
+
+    # Connect to the database at that path with SQLAlchemy
+    db_session = connect_db(database_path, initialization=True)
+
+    # --fetch: wget the AWS IAM Actions, Resources and Condition Keys pages and store them locally.
+    # if --build and --fetch are both supplied, just do --fetch
     if fetch:
         # `wget` the html docs to the local directory
         update_html_docs_directory(HTML_DIRECTORY_PATH)
@@ -68,17 +88,15 @@ def initialize(access_level_overrides_file, fetch):
             HTML_DIRECTORY_PATH, LINKS_YML_FILE_LOCAL)
         print(f"Services: {prefix_list}")
 
-    # Connect to the database at that path with SQLAlchemy
-    db_session = connect_db(database_path, initialization=True)
-
-    # Use the list of services that were listed in the links.yml file
-    all_aws_services = get_list_of_service_prefixes_from_links_file(
-        LINKS_YML_FILE_LOCAL)
-    print(f"Services to build for: ${LINKS_YML_FILE_LOCAL}")
-
-    # Fill in the database with data on the AWS services
-    create_database(db_session, all_aws_services, access_level_overrides_file)
-    print("Created tables for all services!")
+    # initialize --build
+    if build or access_level_overrides_file or fetch:
+        # Use the list of services that were listed in the links.yml file
+        all_aws_services = get_list_of_service_prefixes_from_links_file(
+            LINKS_YML_FILE_LOCAL)
+        print(f"Services to build for: ${LINKS_YML_FILE_LOCAL}")
+        # Fill in the database with data on the AWS services
+        create_database(db_session, all_aws_services, overrides_file)
+        print("Created tables for all services!")
 
     # Query the database for all the services that are now in the database.
     all_aws_service_prefixes = get_all_service_prefixes(db_session)

--- a/policy_sentry/shared/constants.py
+++ b/policy_sentry/shared/constants.py
@@ -26,6 +26,7 @@ DATABASE_FILE_PATH = HOME + CONFIG_DIRECTORY + DATABASE_FILE_NAME
 DEFAULT_ACCESS_OVERRIDES_FILE = abspath(
     dirname(__file__)) + '/data/access-level-overrides.yml'
 
+BUNDLED_DATABASE_FILE_PATH = str(Path(dirname(__file__)).parent) + '/shared/data/' + 'aws.sqlite3'
 # BUNDLED_DATABASE_FILE_PATH = str(Path(dirname(__file__)).parent + '/shared/data/aws.sqlite3')
 # BUNDLED_DATABASE_FILE_PATH = abspath(dirname(__file__)) + '/data/aws.sqlite3'
 

--- a/policy_sentry/writing/template.py
+++ b/policy_sentry/writing/template.py
@@ -6,8 +6,8 @@ from jinja2 import Template
 ACTIONS_TEMPLATE = '''# Generate my policy when I know the Actions
 policy_with_actions:
 - name: {{ name }}
-  description: ''
-  role_arn: ''
+  description: '' # For human auditability
+  role_arn: '' # For human auditability
   actions:
   - ''
 '''
@@ -15,8 +15,8 @@ policy_with_actions:
 CRUD_TEMPLATE = '''# Generate my policy when I know the access levels and ARNs
 policy_with_crud_levels:
 - name: {{ name }}
-  description: ''
-  role_arn: ''
+  description: '' # For human auditability
+  role_arn: '' # For human auditability
   # Insert ARNs under each access level below
   # If you do not need to use certain access levels, delete them.
   read:

--- a/test/test_template.py
+++ b/test/test_template.py
@@ -7,8 +7,8 @@ class TemplateTestCase(unittest.TestCase):
         desired_msg = """# Generate my policy when I know the Actions
 policy_with_actions:
 - name: myrole
-  description: ''
-  role_arn: ''
+  description: '' # For human auditability
+  role_arn: '' # For human auditability
   actions:
   - ''"""
         actions_template = create_actions_template("myrole")
@@ -18,8 +18,8 @@ policy_with_actions:
         desired_msg = """# Generate my policy when I know the access levels and ARNs
 policy_with_crud_levels:
 - name: myrole
-  description: ''
-  role_arn: ''
+  description: '' # For human auditability
+  role_arn: '' # For human auditability
   # Insert ARNs under each access level below
   # If you do not need to use certain access levels, delete them.
   read:


### PR DESCRIPTION
Now you can skip the long wait under the `initialize` command - the initialize command finishes instantly. To rebuild the database, run `initialize --build`, or to build it with the latest AWS docs, use `initialize --fetch`.

Fixes #101 
Fixes #102 