### PR TITLE
Allow risky action analysis using list

### DIFF
--- a/policy_sentry/analysis/analyze.py
+++ b/policy_sentry/analysis/analyze.py
@@ -23,6 +23,23 @@ def read_risky_iam_permissions_text_file(audit_file):
     return risky_actions
 
 
+def determine_risky_actions_from_list(requested_actions, risky_actions):
+    """
+    compare the actions in the policy against a list of high risk actions
+
+    :param requested_actions: A list of the actions that are requested by the policy under evaluation
+    :param risky_actions: A list of risky IAM actions to evaluate.
+    :return: a list of any actions that are included in the file of risky actions
+    """
+
+    risky_actions = get_lowercase_action_list(risky_actions)
+    actions_to_triage = []
+    for action in requested_actions:
+        if action in risky_actions:
+            actions_to_triage.append(action)
+    return actions_to_triage
+
+
 def determine_risky_actions(requested_actions, audit_file):
     """
     compare the actions in the policy against the audit file of high risk actions
@@ -33,12 +50,7 @@ def determine_risky_actions(requested_actions, audit_file):
     """
 
     risky_actions = read_risky_iam_permissions_text_file(audit_file)
-    risky_actions = get_lowercase_action_list(risky_actions)
-    actions_to_triage = []
-    for action in requested_actions:
-        if action in risky_actions:
-            actions_to_triage.append(action)
-    return actions_to_triage
+    return determine_risky_actions_from_list(requested_actions, risky_actions)
 
 
 def expand(action, db_session):

--- a/test/test_analyze.py
+++ b/test/test_analyze.py
@@ -2,7 +2,7 @@ import os
 import unittest
 from policy_sentry.shared.database import connect_db
 from policy_sentry.shared.constants import DATABASE_FILE_PATH
-from policy_sentry.analysis.analyze import analyze_by_access_level
+from policy_sentry.analysis.analyze import analyze_by_access_level, determine_risky_actions_from_list
 from policy_sentry.analysis.finding import Findings
 from policy_sentry.util.policy_files import get_actions_from_json_policy_file, get_actions_from_policy
 from policy_sentry.querying.actions import remove_actions_not_matching_access_level
@@ -257,3 +257,24 @@ class AnalyzeActionsTestCase(unittest.TestCase):
         self.maxDiff = None
         self.assertListEqual(permissions_management_actions, desired_actions_list)
 
+    def test_determine_risky_actions_from_list(self):
+        """test_determine_risky_actions_from_list: Test comparing requested actions to a list of risky actions"""
+        requested_actions = [
+            'ecr:putimage',
+            'ecr:uploadlayerpart',
+            'iam:createaccesskey',
+            'iam:deleteaccesskey'
+        ]
+        risky_actions = [
+            'iam:createaccesskey',
+            'iam:deleteaccesskey',
+            'iam:listaccesskeys',
+            'iam:updateaccesskey'
+        ]
+        actions_to_triage = determine_risky_actions_from_list(requested_actions, risky_actions)
+        expected = [
+            'iam:createaccesskey',
+            'iam:deleteaccesskey'
+        ]
+        self.maxDiff = None
+        self.assertListEqual(actions_to_triage, expected)


### PR DESCRIPTION
This PR adds a `determine_risky_actions_from_list()` function to let library users pass in a list of actions instead of having to read in a file. The existing `determine_risky_actions()` function calls the newly added function with the results of the file read.

I'm happy to add tests, but I was unable to get them to run locally. Any pointers on that? I joined the project's Gitter if it's easier to chat there.