### PR TITLE
Get access levels from statement

### DIFF
--- a/policy_sentry/util/policy_files.py
+++ b/policy_sentry/util/policy_files.py
@@ -4,80 +4,45 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+def get_actions_from_statement(statement):
+    """Given a statement dictionary, create a list of the actions"""
+    actions_list = []
+    # We only want to evaluate policies that have Effect = "Allow"
+    if statement.get('Effect') == 'Deny':
+        return actions_list
+    else:
+        action_clause = statement.get('Action')
+        if not action_clause:
+            logger.debug('No actions contained in statement')
+            return actions_list
+        # Action = "s3:GetObject"
+        if isinstance(action_clause, str):
+            actions_list.append(action_clause)
+        # Action = ["s3:GetObject", "s3:ListBuckets"]
+        elif isinstance(action_clause, list):
+            actions_list.extend(action_clause)
+        else:
+            logger.debug(
+                "Unknown error: The 'Action' is neither a list nor a string")
+    return actions_list
+
+
 # pylint: disable=too-many-branches,too-many-statements
 def get_actions_from_policy(data):
     """Given a policy dictionary, create a list of the actions"""
     actions_list = []
-    # Multiple statements are in the 'Statement' list
-    # pylint: disable=too-many-nested-blocks
-    for i in range(len(data['Statement'])):
-        try:
-            # Statement must be a dict if it's a single statement. Otherwise it will be a list of statements
-            if isinstance(data['Statement'], dict):
-                # We only want to evaluate policies that have Effect = "Allow"
-                # pylint: disable=no-else-continue
-                if data['Statement']['Effect'] == 'Deny':
-                    continue
-                else:
-                    try:
-                        # Action = "s3:GetObject"
-                        if isinstance(data['Statement']['Action'], str):
-                            actions_list.append(
-                                data['Statement']['Action'])
-                        # Action = ["s3:GetObject", "s3:ListBuckets"]
-                        elif isinstance(data['Statement']['Action'], list):
-                            actions_list.extend(
-                                data['Statement']['Action'])
-                        elif 'Action' not in data['Statement']:
-                            logger.debug(
-                                'Action is not a key in the statement')
-                        else:
-                            logger.debug(
-                                "Unknown error: The 'Action' is neither a list nor a string")
-                    except KeyError as k_e:
-                        logger.debug(
-                            "KeyError at get_actions_from_policy", k_e)
-                        exit()
-
-            # Otherwise it will be a list of Sids
-            elif isinstance(data['Statement'], list):
-                # We only want to evaluate policies that have Effect = "Allow"
-                try:
-                    if data['Statement'][i]['Effect'] == 'Deny':
-                        continue
-                    else:
-                        if 'Action' in data['Statement'][i]:
-                            if isinstance(data['Statement'][i]['Action'], str):
-                                actions_list.append(
-                                    data['Statement'][i]['Action'])
-                            elif isinstance(data['Statement'][i]['Action'], list):
-                                actions_list.extend(
-                                    data['Statement'][i]['Action'])
-                            elif data['Statement'][i]['NotAction'] and not data['Statement'][i]['Action']:
-                                logger.debug('Skipping due to NotAction')
-                            else:
-                                logger.debug(
-                                    "Unknown error: The 'Action' is neither a list nor a string")
-                                exit()
-                        else:
-                            continue
-                except KeyError as k_e:
-                    logger.debug(
-                        "KeyError at get_actions_from_policy %s", k_e)
-                    exit()
-            else:
-                logger.critical(
-                    "Unknown error: The 'Action' is neither a list nor a string")
-                # exit()
-        except TypeError as t_e:
-            logger.critical(
-                "TypeError at get_actions_from_policy %s", t_e)
-            exit()
-    try:
-        actions_list = [x.lower() for x in actions_list]
-    except AttributeError as a_e:
-        logger.debug(actions_list)
-        logger.debug("AttributeError: %s", a_e)
+    statement_clause = data.get('Statement')
+    # Statement must be a dict if it's a single statement. Otherwise it will be a list of statements
+    if isinstance(statement_clause, dict):
+        actions_list.extend(get_actions_from_statement(statement_clause))
+    # Otherwise it will be a list of Sids
+    elif isinstance(statement_clause, list):
+        for statement in data['Statement']:
+            actions_list.extend(get_actions_from_statement(statement))
+    else:
+        logger.critical(
+            "Unknown error: The 'Statement' is neither a dict nor a list")
+    actions_list = [x.lower() for x in actions_list]
     actions_list.sort()
     return actions_list
 


### PR DESCRIPTION
This PR adds the ability to analyze a statement within a policy for access levels. I also refactored the existing policy evaluation to use the new `get_actions_from_statement()` function to pull actions from a policy statement.