### PR TITLE
Change bs4 to beautifulsoup4 for dependency pinning

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -31,7 +31,7 @@ parliament = "*"
 black = "==19.10b0"
 
 [packages]
-bs4 = "==0.0.1"
+beautifulsoup4 = "==4.8.2"
 Cython = "==0.29.13"
 html5lib = "==1.0.1"
 lxml = "==4.4.1"

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setuptools.setup(
         'pandas',
         'policyuniverse',
         'PyYAML',
-        'bs4',
+        'beautifulsoup4',
         'html5lib',
         'lxml',
         'jinja2',


### PR DESCRIPTION
bs4 is just a dummy package for beautifulsoup4. Seeing the explicit dependency makes things easier for dependency pinning.