### PR TITLE
Update some query functions to accept "all" as input to service parameter to get results across all AWS service prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ## Future release (Unreleased)
 * Add conditions support
 
+## 0.7.2.1
+* Add `query.actions.get_all_actions_without_resource_constraints`
+
 ## 0.7.2
 * Removed `write-policy-dir` command.
 * Better logging for the `write-policy` command

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 * Add conditions support
 
 ## 0.7.2.1
-* Add `query.actions.get_all_actions_without_resource_constraints`
+* Change `get_actions_that_support_wildcard_arns_only` and `get_actions_at_access_level_that_support_wildcard_arns_only` to accept "all" as input to the `service` parameter. This allows you to get results across all AWS service prefixes.
 
 ## 0.7.2
 * Removed `write-policy-dir` command.

--- a/policy_sentry/bin/policy_sentry
+++ b/policy_sentry/bin/policy_sentry
@@ -2,7 +2,7 @@
 """
     Policy Sentry is a tool for generating least-privilege IAM Policies.
 """
-__version__ = '0.7.2'
+__version__ = '0.7.2.1'
 import click
 from policy_sentry import command
 

--- a/policy_sentry/querying/actions.py
+++ b/policy_sentry/querying/actions.py
@@ -355,3 +355,21 @@ def remove_actions_that_are_not_wildcard_arn_only(db_session, actions_list):
             ):
                 actions_list_placeholder.append(f"{row.service}:{row.name}")
     return actions_list_placeholder
+
+
+def get_all_actions_without_resource_constraints(db_session):
+    actions_list = []
+    rows = db_session.query(ActionTable.service, ActionTable.name).filter(
+        and_(
+            # ActionTable.service.ilike(service),
+            ActionTable.resource_arn_format.like("*"),
+            ActionTable.name.notin_(
+                db_session.query(ActionTable.name).filter(
+                    ActionTable.resource_arn_format.notlike("*")
+                )
+            ),
+        )
+    )
+    for row in rows:
+        actions_list.append(get_full_action_name(row.service, row.name))
+    return actions_list

--- a/test/querying/test_query_actions.py
+++ b/test/querying/test_query_actions.py
@@ -14,6 +14,7 @@ from policy_sentry.querying.actions import (
     remove_actions_that_are_not_wildcard_arn_only,
     get_dependent_actions,
     remove_actions_not_matching_access_level,
+    get_all_actions_without_resource_constraints
 )
 
 db_session = connect_db(DATABASE_FILE_PATH)
@@ -319,3 +320,9 @@ class QueryActionsTestCase(unittest.TestCase):
         )
         self.maxDiff = None
         self.assertListEqual(desired_output, output)
+
+    # def test_get_all_actions_without_resource_constraints(self):
+    #     """query.actions.get_all_actions_without_resource_constraints"""
+    #     output = get_all_actions_without_resource_constraints(db_session)
+    #     print(json.dumps(output, indent=4))
+    #     print()

--- a/test/querying/test_query_actions.py
+++ b/test/querying/test_query_actions.py
@@ -14,7 +14,6 @@ from policy_sentry.querying.actions import (
     remove_actions_that_are_not_wildcard_arn_only,
     get_dependent_actions,
     remove_actions_not_matching_access_level,
-    get_all_actions_without_resource_constraints
 )
 
 db_session = connect_db(DATABASE_FILE_PATH)
@@ -320,9 +319,14 @@ class QueryActionsTestCase(unittest.TestCase):
         )
         self.maxDiff = None
         self.assertListEqual(desired_output, output)
-
+    #
     # def test_get_all_actions_without_resource_constraints(self):
     #     """query.actions.get_all_actions_without_resource_constraints"""
-    #     output = get_all_actions_without_resource_constraints(db_session)
+    #     output = get_actions_that_support_wildcard_arns_only(db_session, "all")
     #     print(json.dumps(output, indent=4))
+    #     print()
+    #
+    #     output = get_actions_at_access_level_that_support_wildcard_arns_only(db_session, "all", "Write")
+    #     print(json.dumps(output, indent=4))
+    #     output = get_actions_at_access_level_that_support_wildcard_arns_only(db_session, "all", "Permissions management")
     #     print()


### PR DESCRIPTION
Changed `get_actions_that_support_wildcard_arns_only` and `get_actions_at_access_level_that_support_wildcard_arns_only` to accept "all" as input to the `service` parameter. This allows you to get results across all AWS service prefixes.