### PR TITLE
Added skip-resource-constraints feature for CRUD mode and docs to support. Fixes #145

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ## Future release (Unreleased)
 * Add conditions support
 
+## 0.7.3 (Unreleased)
+* Add skip-resource-constraints feature for CRUD mode (Fixes #145)
+
 ## 0.7.2.1
 * Change `get_actions_that_support_wildcard_arns_only` and `get_actions_at_access_level_that_support_wildcard_arns_only` to accept "all" as input to the `service` parameter. This allows you to get results across all AWS service prefixes.
 

--- a/docs/user-guide/writing-policies/crud-examples.rst
+++ b/docs/user-guide/writing-policies/crud-examples.rst
@@ -1,0 +1,158 @@
+CRUD Mode Examples
+==================
+
+This will show valid template inputs and their outputs for CRUD mode. CRUD mode may appear to be complicated, but in reality it is quite simple. This page will avoid being overly explanatory and will just show the input and output as a reference.
+
+
+Example 1: Basic CRUD
+---------------------
+
+The basic CRUD mode gives you actions at the specified access level, constrained to the specific resource ARNs supplied.
+
+**Input**:
+
+.. code-block:: yaml
+
+    mode: crud
+    read:
+    - 'arn:aws:ssm:us-east-1:123456789012:parameter/myparameter'
+
+**Output**:
+
+.. code-block:: json
+
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "SsmReadParameter",
+                "Effect": "Allow",
+                "Action": [
+                    "ssm:GetParameter",
+                    "ssm:GetParameterHistory",
+                    "ssm:GetParameters",
+                    "ssm:GetParametersByPath",
+                    "ssm:ListTagsForResource"
+                ],
+                "Resource": [
+                    "arn:aws:ssm:us-east-1:123456789012:parameter/myparameter"
+                ]
+            }
+        ]
+    }
+
+
+Example 2: Skipping Resource Constraints
+------------------------------------------
+
+In basic CRUD mode, Policy Sentry forces you to use resource constraints, but perhaps you do want to allow `kms:Decrypt` to `*` and there are mitigating circumstances that mean it is not a security risk to your organization. For example - let's say that given the context of your organization and its AWS security strategy, you can’t know the KMS Key Alias or Key ID beforehand. However, all of the KMS  keys are tightly controlled via resource based policies and provisioned via Terraform/Cloudformation, therefore `kms:Decrypt` is ok. And in order to use Policy Sentry you’d need a way to handle exceptions/overrides.
+
+The `skip-resource-constraints` section allows you to do this.
+
+We avoid abuse by requiring that if you list actions under the skip-resource-constraints section, then you should have to list the actions out individually (I.e., don’t allow S3:*)
+
+**Input**:
+
+.. code-block:: yaml
+
+    mode: crud
+    skip-resource-constraints:
+    - s3:GetObject
+    - s3:PutObject
+    - ssm:GetParameter
+    - ssm:GetParameters
+
+
+**Output**:
+
+.. code-block:: json
+
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "SkipResourceConstraints",
+                "Effect": "Allow",
+                "Action": [
+                    "s3:GetObject",
+                    "s3:PutObject",
+                    "ssm:GetParameter",
+                    "ssm:GetParameters"
+                ],
+                "Resource": [
+                    "*"
+                ]
+            }
+        ]
+    }
+
+
+Example 3: Wildcard-only - Single Actions
+-----------------------------------------
+
+This is for actions that do not support resource ARN constraints, such as `secretsmanager:CreateSecret`.
+
+**Input**:
+
+.. code-block:: yaml
+
+    mode: crud
+    wildcard-only:
+        single-actions:
+        - secretsmanager:CreateSecret
+
+**Output**:
+
+.. code-block:: json
+
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "MultMultNone",
+                "Effect": "Allow",
+                "Action": [
+                    "secretsmanager:CreateSecret"
+                ],
+                "Resource": [
+                    "*"
+                ]
+            }
+        ]
+    }
+
+
+Example 4: Wildcard only - Bulk Selection Service-Wide
+------------------------------------------------------
+
+As mentioned before, there are some actions that do not support resource constraints - but all of those actions have access levels. You can use this strategy to "bulk select" wildcard-only actions at different access levels. It improves the user experience so you don't have to actually know the details of individual IAM Actions, just the service prefixes and access levels.
+
+**Input**:
+
+.. code-block:: yaml
+
+    mode: crud
+    wildcard-only:
+        service-list:
+        - s3
+
+
+**Output**:
+
+.. code-block:: json
+
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "MultMultNone",
+                "Effect": "Allow",
+                "Action": [
+                    "s3:ListAllMyBuckets"
+                ],
+                "Resource": [
+                    "*"
+                ]
+            }
+        ]
+    }

--- a/docs/user-guide/writing-policies/crud-mode.rst
+++ b/docs/user-guide/writing-policies/crud-mode.rst
@@ -25,7 +25,6 @@ Example:
 Instructions
 ------------
 
-
 * To generate a policy according to resources and access levels, start by creating a template with this command so you can just fill out the ARNs:
 
 .. code-block:: bash

--- a/docs/user-guide/writing-policies/index.rst
+++ b/docs/user-guide/writing-policies/index.rst
@@ -8,4 +8,5 @@ Writing IAM Policies
 
    crud-mode
    actions-mode
+   crud-examples
 

--- a/examples/yml/crud-cases/1-ssm-read.yml
+++ b/examples/yml/crud-cases/1-ssm-read.yml
@@ -1,0 +1,3 @@
+mode: crud
+read:
+- 'arn:aws:ssm:us-east-1:123456789012:parameter/myparameter'

--- a/examples/yml/crud-cases/2-skip-resource-constraints.yml
+++ b/examples/yml/crud-cases/2-skip-resource-constraints.yml
@@ -1,0 +1,6 @@
+mode: crud
+skip-resource-constraints:
+- s3:GetObject
+- s3:PutObject
+- ssm:GetParameter
+- ssm:GetParameters

--- a/examples/yml/crud-cases/3-wildcard-only-single-actions.yml
+++ b/examples/yml/crud-cases/3-wildcard-only-single-actions.yml
@@ -1,0 +1,4 @@
+mode: crud
+wildcard-only:
+    single-actions:
+    - secretsmanager:CreateSecret

--- a/examples/yml/crud-cases/4-wildcard-only-bulk-selection.yml
+++ b/examples/yml/crud-cases/4-wildcard-only-bulk-selection.yml
@@ -1,0 +1,4 @@
+mode: crud
+wildcard-only:
+    service-list:
+    - s3

--- a/examples/yml/crud-with-override.yml
+++ b/examples/yml/crud-with-override.yml
@@ -1,0 +1,11 @@
+mode: crud
+name: 'RoleNameWithCRUD'
+permissions-management:
+- arn:aws:s3:::example-org-s3-access-logs
+wildcard-only:
+    single-actions:
+    - secretsmanager:CreateSecret
+skip-resource-constraints:
+- ssm:GetParameter
+- ssm:GetParameters
+- ssm:GetParametersByPath

--- a/policy_sentry/writing/template.py
+++ b/policy_sentry/writing/template.py
@@ -22,6 +22,9 @@ tagging:
 - ''
 permissions-management:
 - ''
+# Skip resource constraint requirements by listing actions here.
+skip-resource-constraints:
+- ''
 # Actions that do not support resource constraints
 wildcard-only:
   single-actions: # standalone actions
@@ -47,6 +50,7 @@ CRUD_TEMPLATE_DICT = {
     "list": [],
     "tagging": [],
     "permissions-management": [],
+    "skip-resource-constraints": [],
     "wildcard-only": {
         "single-actions": [],
         "service-read": [],
@@ -57,11 +61,7 @@ CRUD_TEMPLATE_DICT = {
     },
 }
 
-ACTIONS_TEMPLATE_DICT = {
-    "mode": "actions",
-    "name": "",
-    "actions": [],
-}
+ACTIONS_TEMPLATE_DICT = {"mode": "actions", "name": "", "actions": []}
 
 
 def create_crud_template(name):

--- a/policy_sentry/writing/validate.py
+++ b/policy_sentry/writing/validate.py
@@ -45,6 +45,7 @@ CRUD_SCHEMA = Schema(
             Optional("service-tagging"): [str],
             Optional("service-permissions-management"): [str],
         },
+        Optional("skip-resource-constraints"): [str],
     }
 )
 

--- a/test/writing/test_sid_group_actions.py
+++ b/test/writing/test_sid_group_actions.py
@@ -1,0 +1,76 @@
+import unittest
+import json
+import os
+from policy_sentry.shared.database import connect_db
+from policy_sentry.writing.sid_group import SidGroup
+from policy_sentry.shared.constants import DATABASE_FILE_PATH
+
+db_session = connect_db(DATABASE_FILE_PATH)
+
+crud_with_override_template = os.path.abspath(
+    os.path.join(
+        os.path.dirname(__file__),
+        os.path.pardir,
+        os.path.pardir,
+        "examples",
+        "crud-with-override.yml",
+    )
+)
+
+
+class SidGroupActionsTestCase(unittest.TestCase):
+    def test_actions_test_case(self):
+        cfg = {
+            "mode": "actions",
+            "name": "RoleNameWithCRUD",
+            "actions": [
+                "kms:CreateGrant",
+                "kms:CreateCustomKeyStore",
+                "ec2:AuthorizeSecurityGroupEgress",
+                "ec2:AuthorizeSecurityGroupIngress",
+            ],
+        }
+        sid_group = SidGroup()
+        output = sid_group.process_template(db_session, cfg)
+        print(json.dumps(output, indent=4))
+        desired_output = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Sid": "KmsPermissionsmanagementKey",
+                    "Effect": "Allow",
+                    "Action": [
+                        "kms:CreateGrant"
+                    ],
+                    "Resource": [
+                        "arn:${Partition}:kms:${Region}:${Account}:key/${KeyId}"
+                    ]
+                },
+                {
+                    "Sid": "MultMultNone",
+                    "Effect": "Allow",
+                    "Action": [
+                        "cloudhsm:DescribeClusters",
+                        "kms:CreateCustomKeyStore"
+                    ],
+                    "Resource": [
+                        "*"
+                    ]
+                },
+                {
+                    "Sid": "Ec2WriteSecuritygroup",
+                    "Effect": "Allow",
+                    "Action": [
+                        "ec2:AuthorizeSecurityGroupEgress",
+                        "ec2:AuthorizeSecurityGroupIngress"
+                    ],
+                    "Resource": [
+                        "arn:${Partition}:ec2:${Region}:${Account}:security-group/${SecurityGroupId}"
+                    ]
+                }
+            ]
+        }
+        self.maxDiff = None
+        print(json.dumps(output, indent=4))
+        self.assertDictEqual(output, desired_output)
+

--- a/test/writing/test_template.py
+++ b/test/writing/test_template.py
@@ -25,6 +25,9 @@ tagging:
 - ''
 permissions-management:
 - ''
+# Skip resource constraint requirements by listing actions here.
+skip-resource-constraints:
+- ''
 # Actions that do not support resource constraints
 wildcard-only:
   single-actions: # standalone actions
@@ -41,4 +44,5 @@ wildcard-only:
   service-permissions-management:
   - ''"""
         crud_template = create_crud_template("myrole")
+        self.maxDiff = None
         self.assertEqual(desired_msg, crud_template)

--- a/test/writing/test_write_policy_library_usage.py
+++ b/test/writing/test_write_policy_library_usage.py
@@ -160,7 +160,7 @@ class WritePolicyWithLibraryOnly(unittest.TestCase):
         )
         # print("desired_crud_policy")
         # print(json.dumps(desired_crud_policy, indent=4))
-        # print("policy")
-        # print(json.dumps(policy, indent=4))
+        print("policy")
+        print(json.dumps(policy, indent=4))
         self.maxDiff = None
         self.assertDictEqual(desired_crud_policy, policy)


### PR DESCRIPTION
Now you can override individual actions so that they skip resource constraint requirements.


Example input:

```yaml
mode: crud
skip-resource-constraints:
- s3:GetObject
- s3:PutObject
- ssm:GetParameter
- ssm:GetParameters
```


Example output:

```json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Sid": "SkipResourceConstraints",
            "Effect": "Allow",
            "Action": [
                "s3:GetObject",
                "s3:PutObject",
                "ssm:GetParameter",
                "ssm:GetParameters"
            ],
            "Resource": [
                "*"
            ]
        }
    ]
}
```