### PR TITLE
Quick fix for remove_actions_not_matching_access_level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ## Future release (Unreleased)
 * Add conditions support
 
-## 0.8.0.3 (Unreleased)
+## 0.8.0.3 (2020-04-16)
 * Added logging for Query functions (#161)
 * Added `get_expanded_policy` function and moved some of the `analysis.analyze` functions to `analysis.expand` (Fixes #164)
 * Fixed `analyze_by_access_level` function (Fixes #162)

--- a/policy_sentry/bin/cli.py
+++ b/policy_sentry/bin/cli.py
@@ -2,7 +2,7 @@
 """
     Policy Sentry is a tool for generating least-privilege IAM Policies.
 """
-__version__ = "0.8.0.2"
+__version__ = "0.8.0.3"
 import click
 from policy_sentry import command
 

--- a/policy_sentry/querying/actions.py
+++ b/policy_sentry/querying/actions.py
@@ -242,17 +242,19 @@ def remove_actions_not_matching_access_level(actions_list, access_level):
 
     def is_access_level(some_service_prefix, some_action):
         service_prefix_data = get_service_prefix_data(some_service_prefix.lower())
-        result = None
-        for action_instance in service_prefix_data["privileges"]:
-            if action_instance.get("access_level") == access_level:
-                logger.debug(f"remove_actions_not_matching_access_level: Provided access level is {access_level}, matches {action_instance.get('access_level')}")
-                if action_instance.get("privilege").lower() == some_action.lower():
-                    result = f"{some_service_prefix}:{action_instance.get('privilege')}"
-                    break
-        if not result:
+        this_result = None
+        if "privileges" in service_prefix_data:
+            for action_instance in service_prefix_data["privileges"]:
+                if action_instance.get("access_level") == access_level:
+                    logger.debug(f"remove_actions_not_matching_access_level: Provided access level is {access_level}, "
+                                 f"matches {action_instance.get('access_level')}")
+                    if action_instance.get("privilege").lower() == some_action.lower():
+                        this_result = f"{some_service_prefix}:{action_instance.get('privilege')}"
+                        break
+        if not this_result:
             return False
         else:
-            return result
+            return this_result
 
     for action in actions_list:
         service_prefix, action_name = action.split(":")

--- a/policy_sentry/querying/actions.py
+++ b/policy_sentry/querying/actions.py
@@ -243,14 +243,15 @@ def remove_actions_not_matching_access_level(actions_list, access_level):
     def is_access_level(some_service_prefix, some_action):
         service_prefix_data = get_service_prefix_data(some_service_prefix.lower())
         this_result = None
-        if "privileges" in service_prefix_data:
-            for action_instance in service_prefix_data["privileges"]:
-                if action_instance.get("access_level") == access_level:
-                    logger.debug(f"remove_actions_not_matching_access_level: Provided access level is {access_level}, "
-                                 f"matches {action_instance.get('access_level')}")
-                    if action_instance.get("privilege").lower() == some_action.lower():
-                        this_result = f"{some_service_prefix}:{action_instance.get('privilege')}"
-                        break
+        if service_prefix_data:
+            if "privileges" in service_prefix_data:
+                for action_instance in service_prefix_data["privileges"]:
+                    if action_instance.get("access_level") == access_level:
+                        logger.debug(f"remove_actions_not_matching_access_level: Provided access level is {access_level}, "
+                                     f"matches {action_instance.get('access_level')}")
+                        if action_instance.get("privilege").lower() == some_action.lower():
+                            this_result = f"{some_service_prefix}:{action_instance.get('privilege')}"
+                            break
         if not this_result:
             return False
         else:


### PR DESCRIPTION
If "privileges" did not exist it would throw an error like this: `TypeError: 'NoneType' object is not subscriptable`. This fixes that issue.