### PR TITLE
allow initialize to be used as a library function

### DIFF
--- a/policy_sentry/bin/cli.py
+++ b/policy_sentry/bin/cli.py
@@ -15,7 +15,7 @@ def policy_sentry():
     """
 
 
-policy_sentry.add_command(command.initialize.initialize)
+policy_sentry.add_command(command.initialize.initialize_command)
 policy_sentry.add_command(command.write_policy.write_policy)
 policy_sentry.add_command(command.create_template.create_template)
 policy_sentry.add_command(command.query.query)

--- a/policy_sentry/command/initialize.py
+++ b/policy_sentry/command/initialize.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 click_log.basic_config(logger)
 
 
-@click.command(short_help="Create a local datastore to store AWS IAM information.")
+@click.command(name="initialize", short_help="Create a local datastore to store AWS IAM information.")
 @click.option(
     "--access-level-overrides-file",
     type=str,
@@ -52,12 +52,18 @@ click_log.basic_config(logger)
     "the python package. Defaults to false",
 )
 @click_log.simple_verbosity_option(logger)
+def initialize_command(access_level_overrides_file, fetch, build):
+    """
+    CLI command for initializing the local data file
+    """
+    initialize(access_level_overrides_file, fetch, build)
+
+
 def initialize(access_level_overrides_file, fetch, build):
     """
     Initialize the local data file to store AWS IAM information, which can be used to generate IAM policies, and for
     querying the database.
     """
-
     if not access_level_overrides_file:
         overrides_file = LOCAL_ACCESS_OVERRIDES_FILE
     else:
@@ -105,7 +111,6 @@ def initialize(access_level_overrides_file, fetch, build):
     print(f"Total AWS services in the IAM database: {total_count_of_services}")
     logger.debug("\nService prefixes:")
     logger.debug(", ".join(all_aws_service_prefixes))
-
 
 def create_policy_sentry_config_directory():
     """

--- a/policy_sentry/command/initialize.py
+++ b/policy_sentry/command/initialize.py
@@ -112,6 +112,7 @@ def initialize(access_level_overrides_file, fetch, build):
     logger.debug("\nService prefixes:")
     logger.debug(", ".join(all_aws_service_prefixes))
 
+
 def create_policy_sentry_config_directory():
     """
     Creates a config directory at $HOME/.policy_sentry/

--- a/policy_sentry/command/initialize.py
+++ b/policy_sentry/command/initialize.py
@@ -59,7 +59,7 @@ def initialize_command(access_level_overrides_file, fetch, build):
     initialize(access_level_overrides_file, fetch, build)
 
 
-def initialize(access_level_overrides_file, fetch, build):
+def initialize(access_level_overrides_file=None, fetch=False, build=False):
     """
     Initialize the local data file to store AWS IAM information, which can be used to generate IAM policies, and for
     querying the database.


### PR DESCRIPTION
Prior to this it was difficult to use the function from another script because it's wrapped in click.

This doesn't change any functionality, just adds a command facade that is used for click and copies the `initialize` logic to a separate callable function.

What this allows is:
```python
from policy_sentry.command.initialize import initialize

initialize(None, True, True) # fetches and builds database file
```

Happy to discuss the merits of this approach. This was the easiest way I discovered to initialize the database from another script.