### PR TITLE
Point to a stable link to the aws_config hacking script

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,7 +511,7 @@ For the full example, including GIFs depicting real output, see the README for t
 
 [1]: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_actions-resources-contextkeys.html
 [2]: https://nose.readthedocs.io/en/latest/
-[3]: https://github.com/ansible/ansible/blob/devel/hacking/aws_config/build_iam_policy_framework.py
+[3]: https://github.com/ansible/ansible/blob/stable-2.9/hacking/aws_config/build_iam_policy_framework.py
 [4]: https://github.com/evilpete/aws_access_adviser
 [5]: https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_identity-vs-resource.html
 [6]: https://docs.aws.amazon.com/IAM/latest/APIReference/API_SimulatePrincipalPolicy.html


### PR DESCRIPTION
The link `devel` no longer contains the script linked in the docs because ansible moved AWS modules out of the main `ansible/ansible` repo. 