### PR TITLE
Auto update

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,6 +6,10 @@ trim_trailing_whitespace = true
 end_of_line = lf
 charset = utf-8
 
+[.github/workflows/*.yml]
+indent_style = space
+indent_size = 2
+
 # Docstrings and comments use max_line_length = 79
 [*.py]
 max_line_length = 119

--- a/.github/scripts/update_data.py
+++ b/.github/scripts/update_data.py
@@ -1,0 +1,11 @@
+from policy_sentry.shared import constants
+
+constants.CONFIG_DIRECTORY = "/tmp/.policy_sentry"
+constants.LOCAL_DATASTORE_FILE_PATH = "/tmp/.policy_sentry/iam-definition.json"
+constants.LOCAL_ACCESS_OVERRIDES_FILE = "/tmp/.policy_sentry/access-level-overrides.yml"
+constants.LOCAL_HTML_DIRECTORY_PATH = "/tmp/.policy_sentry/data/docs"
+
+from policy_sentry.command.initialize import initialize
+
+if __name__ == '__main__':
+    initialize(None, True, True)

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -2,8 +2,8 @@ name: Update
 
 on:
   schedule:
-  # once a week on Sunday
-    - cron:  '0 0 * * 0'
+  # Run on the first day of the month
+    - cron:  '0 0 1 * *'
 
 jobs:
   update-actions:

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,35 @@
+name: Update
+
+on:
+  push:
+    branches:
+      - auto-update
+  schedule:
+  # once a week on Sunday
+    - cron:  '0 0 * * 0'
+
+jobs:
+  update-actions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+      - name: install deps
+        run: pip install requests schema PyYAML click click_log beautifulsoup4
+      - name: install policy_sentry
+        run: echo "::set-env name=PYTHONPATH::$(pwd)"
+      - name: Run initialize
+        run: |
+          python .github/scripts/update_data.py
+          cp -f /tmp/.policy_sentry/iam-definition.json $(pwd)/policy_sentry/shared/data/iam-definition.json
+          cp -rf /tmp/.policy_sentry/data/docs $(pwd)/policy_sentry/shared/data/
+      - name: PR if files were updated
+        uses: peter-evans/create-pull-request@v2
+        with:
+          commit-message: Update database
+          title: 'Updates database'
+          body: This is an automated PR created because AWS IAM definitions have changed.

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,6 +1,9 @@
 name: Update
 
 on:
+  push:
+    branches:
+      - auto-update
   schedule:
   # Run on the first day of the month
     - cron:  '0 0 1 * *'

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,9 +1,6 @@
 name: Update
 
 on:
-  push:
-    branches:
-      - auto-update
   schedule:
   # Run on the first day of the month
     - cron:  '0 0 1 * *'

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -22,6 +22,10 @@ jobs:
       - name: Run initialize
         run: |
           python .github/scripts/update_data.py
+          if [[ $(du -m /tmp/.policy_sentry/iam-definition.json | cut -f1) -lt 3 ]]; then
+            echo "File size is less than 3 MB, something is wrong with this update"
+            exit 1
+          fi
           cp -f /tmp/.policy_sentry/iam-definition.json $(pwd)/policy_sentry/shared/data/iam-definition.json
           cp -rf /tmp/.policy_sentry/data/docs $(pwd)/policy_sentry/shared/data/
       - name: PR if files were updated

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,9 +1,6 @@
 name: Update
 
 on:
-  push:
-    branches:
-      - auto-update
   schedule:
   # once a week on Sunday
     - cron:  '0 0 * * 0'


### PR DESCRIPTION
Addresses #186

This change adds a github action that runs the initialize function on a cron schedule and PRs any updates to `docs` or `iam-definition.json` should they exist.

To see an example run checkout my fork. Here is the action running: https://github.com/zscholl/policy_sentry/actions/runs/122024288

And here is the PR it created: https://github.com/zscholl/policy_sentry/pull/1

The PR is highly customizable if we want something different. Check out the action for more details on configuration: https://github.com/peter-evans/create-pull-request


Also included is a small change to the editor config. I was wrestling with it when editing actions files.