### PR TITLE
write-policy --fmt yaml is now possible. Fixes #228

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Speed improvements: The IAM definition is now a dictionary instead of a list.
 * Fixed issue where elasticloadbalancing v1 was showing up in query results but v2 was not. Fixes #226
 * Supports "required" as an additional key for privilege (Fixes #230)
+* `write-policy --fmt yaml` is now supported
 
 ## 0.8.8 (2020-09-15)
 * Fixes issue with querying condition keys (#225)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,21 +28,18 @@ nav:
   - "<b>Writing Policies</b>":
     - "<b>CRUD Mode</b>":
       - CRUD Mode: 'writing-policies/crud-mode.md'
+      - "<i>Example</i>: Basic CRUD": 'writing-policies/access-levels-example.md'
+      - "<i>Example</i>: Skipping Resource Constraints": 'writing-policies/skipping-resource-constraints.md'
+      - "<i>Example</i>: Excluding Actions": 'writing-policies/excluding-actions.md'
+      - "<i>Example</i>: Single actions": 'writing-policies/wildcard-only/example-single-actions.md'
+      - "<i>Example</i>: Service-wide": 'writing-policies/wildcard-only/example-service-wide.md'
+      - "<i>Example</i>: Combining approaches": 'writing-policies/wildcard-only/combined-approaches.md'
       - "<b>Wildcard-only</b>":
         - Introduction: 'writing-policies/wildcard-only/introduction.md'
         - Single actions: 'writing-policies/wildcard-only/single-actions.md'
         - Service-wide: 'writing-policies/wildcard-only/service-wide.md'
-      - Minimizing characters: 'writing-policies/minimization.md'
     - Actions Mode: 'writing-policies/actions-mode.md'
-    - "<b>Examples</b>":
-      - "<b>Feature examples</b>":
-        - "<i>Example</i>: Basic CRUD": 'writing-policies/access-levels-example.md'
-        - "<i>Example</i>: Skipping Resource Constraints": 'writing-policies/skipping-resource-constraints.md'
-        - "<i>Example</i>: Excluding Actions": 'writing-policies/excluding-actions.md'
-        - "<i>Example</i>: Single actions": 'writing-policies/wildcard-only/example-single-actions.md'
-        - "<i>Example</i>: Service-wide": 'writing-policies/wildcard-only/example-service-wide.md'
-        - "<i>Example</i>: Combining approaches": 'writing-policies/wildcard-only/combined-approaches.md'
-
+    - Minimizing characters: 'writing-policies/minimization.md'
   - "<b>Querying the IAM Database</b>":
     - Overview: 'querying/querying.md'
     - Action Table: 'querying/action-table.md'

--- a/policy_sentry/command/write_policy.py
+++ b/policy_sentry/command/write_policy.py
@@ -21,7 +21,6 @@ click_log.basic_config(logger)
 @click.option(
     "--input-file",
     type=str,
-    # required=True,
     help="Path of the YAML File used for generating policies",
 )
 @click.option(
@@ -31,8 +30,15 @@ click_log.basic_config(logger)
     help="Minimize the resulting statement with *safe* usage of wildcards to reduce policy length. "
     "Set this to the character length you want - for example, 4",
 )
+@click.option(
+    "--fmt",
+    type=click.Choice(["yaml", "json"]),
+    default="json",
+    required=False,
+    help='Format output as YAML or JSON. Defaults to "json"',
+)
 @click_log.simple_verbosity_option(logger)
-def write_policy(input_file, minimize):
+def write_policy(input_file, minimize, fmt):
     """
     Write least-privilege IAM policies, restricting all actions to resource ARNs.
     """
@@ -46,21 +52,10 @@ def write_policy(input_file, minimize):
             logger.critical(exc)
             sys.exit()
     policy = write_policy_with_template(cfg, minimize)
-    print(json.dumps(policy, indent=4))
-    #
-    # if input_file:
-    #     cfg = read_yaml_file(input_file)
-    # else:
-    #     try:
-    #         cfg = yaml.safe_load(sys.stdin)
-    #     except yaml.YAMLError as exc:
-    #         logger.critical(exc)
-    #         sys.exit()
-    #
-    # # User supplies file containing resource-specific access levels
-    # sid_group = SidGroup()
-    # policy = sid_group.process_template(cfg, minimize)
-    # print(json.dumps(policy, indent=4))
+    if fmt == "yaml":
+        print(yaml.dump(policy, sort_keys=False))
+    else:
+        print(json.dumps(policy, indent=4))
 
 
 def write_policy_with_template(cfg, minimize=None):


### PR DESCRIPTION
## What does this PR do?

Fixes #228 by allowing output to YAML

`policy_sentry write-policy --fmt yaml` is now supported

## What gif best describes this PR or how it makes you feel?

![image](https://user-images.githubusercontent.com/3422255/93628919-62310d00-f9b5-11ea-8cb9-b35ab497003c.png)

## Completion checklist

- [x] Additions and changes have unit tests
- [x] [Unit tests, Pylint, security testing, and Integration tests are passing.](https://github.com/salesforce/policy_sentry/actions). GitHub actions does this automatically
- [x] The pull request has been appropriately labeled using the provided PR labels
