### PR TITLE
adding release drafter github action 

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,41 @@
+name-template: 'v$RESOLVED_VERSION 🌈'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+      - 'quick-fix'
+  - title: '🧰 Maintenance'
+    label:
+      - 'chore'
+      - 'maintenance'
+      - 'maintain'
+      - 'cleanup'
+  - title: '📝 Documentation'
+    label:
+      - 'documentation'
+      - 'docs'
+
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,14 @@
+name: Release Drafter
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -2,7 +2,7 @@ name: Release Drafter
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, master ]
 
 jobs:
   update_release_draft:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Backend methods:
   * Added some utility functions (`get_statement_from_policy_using_sid`, `get_sid_names_from_policy` to make it easier to future-proof unit tests that rely on the ever-changing AWS IAM data.
   * Bug fix for `get_actions_for_service` (Fixes #245)
+* adding release drafter as github actions (Fixes #257)
 
 ## 0.9.0 (2020-10-01)
 * Speed improvements: The IAM definition is now a dictionary instead of a list.

--- a/docs/contributing/release-drafter.md
+++ b/docs/contributing/release-drafter.md
@@ -1,0 +1,21 @@
+# Release Drafter
+
+1. Every time a PR is merged, the draft release note is updated 
+   to add a entry for this change
+2. We have a github release-drafter action which automatically 
+   does this after a PR is merged.
+3. It also increments the release version if this is the first PR for a new release. 
+   Note: This will only update the draft release note. We still have to bump 
+   the version as per [versioning document](https://github.com/salesforce/policy_sentry/blob/master/docs/contributing/versioning.md)
+4. When we are ready to publish the release, we use the drafted 
+   release note to do so.
+5. Release drafter categorizes the changes in the release into Features, BugFixes, Maintenance, 
+   Documentation categories as per the labels added to the PR
+
+
+Adding labels to the PR:
+
+- Contributors can add appropriate label 
+  to the PR (feature, bugfix, documentation, maintenance etc.)
+- If PR contributor does not have the permission, 
+  Maintainers should add the label.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,6 +77,7 @@ nav:
     - Testing: 'contributing/testing.md'
     - IAM database: 'contributing/iam-database.md'
     - Versioning: 'contributing/versioning.md'
+    - Release Drafter: 'contributing/release-drafter.md'
     - Roadmap: 'contributing/roadmap.md'
 
   - "<b>Appendices</b>":


### PR DESCRIPTION
## What does this PR do?
Address #257
Adding GitHub workflow which creates draft release notes
Adding a config file for this

**Could not find a way to automatically update version in policy_sentry/bin/cli.py as described in the issue**

[//]: # (Required: Describe the effects of your pull request in detail. If
multiple changes are involved, a bulleted list is often useful.)

## What gif best describes this PR or how it makes you feel?

![Alt Text](https://media.giphy.com/media/3ohhwoy4AB7fXp0GVq/giphy.gif)

[//]: # (Encouraged: Insert an appropriate gif/meme to brighten up your reviewer's day.)

## Completion checklist

- [x] CHANGELOG.md has been updated to reflect the changes
- [ ] Additions and changes have unit tests
- [ ] [Unit tests, Pylint, security testing, and Integration tests are passing.](https://github.com/salesforce/policy_sentry/actions). GitHub actions does this automatically
- [x] The pull request has been appropriately labeled using the provided PR labels
