### PR TITLE
Add `--resource-type` flag to `policy_sentry query action-table` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * write-policy:
   * Minimization is improved by grouping results based on ARNs (#252)
 * query:
-  * `--resource-type` flag is added to `policy_sentry query action-table` command
+  * `--resource-type` flag added to `policy_sentry query action-table` command (Fixes #255)
 * Backend methods:
   * Added some utility functions (`get_statement_from_policy_using_sid`, `get_sid_names_from_policy` to make it easier to future-proof unit tests that rely on the ever-changing AWS IAM data.
   * Bug fix for `get_actions_for_service` (Fixes #245)

--- a/docs/querying/action-table.md
+++ b/docs/querying/action-table.md
@@ -5,10 +5,13 @@ Action table
 # NOTE: Use --fmt yaml or --fmt json to change the output format. Defaults to json for querying
 
 # Get a list of actions that do not support resource constraints
-policy_sentry query action-table --service s3 --wildcard-only --fmt yaml
+policy_sentry query action-table --service s3 --resource-type '*' --fmt yaml
 
 # Get a list of actions at the "Read" level in S3 that do not support resource constraints
-policy_sentry query action-table --service s3 --access-level read --wildcard-only --fmt yaml
+policy_sentry query action-table --service s3 --access-level read --resource-type '*' --fmt yaml
+
+# Get a list of actions at the "Write" level in SSM service for resource type "parameter"
+policy_sentry query action-table --service ssm --access-level write --resource-type parameter
 
 # Get a list of all IAM Actions available to the RAM service
 policy_sentry query action-table --service ram
@@ -21,6 +24,7 @@ policy_sentry query action-table --service ram --access-level permissions-manage
 
 # Get a list of all IAM actions under the SES service that support the `ses:FeedbackAddress` condition key.
 policy_sentry query action-table --service ses --condition ses:FeedbackAddress
+
 ```
 
 Options
@@ -42,10 +46,8 @@ Options:
   --condition TEXT                If action table is chosen, you can supply a
                                   condition key to show a list of all IAM
                                   actions that support the condition key.
-  --wildcard-only                 If action table is chosen, show the IAM
-                                  actions that only support wildcard resources
-                                  - i.e., cannot support ARNs in the resource
-                                  block.
+  --resource-type TEXT            Supply a resource type to show a list of all
+                                  IAM actions that support the resource type.
   --fmt [yaml|json]               Format output as YAML or JSON. Defaults to
                                   "yaml"
   --v                             Set the logging level. Choices are CRITICAL, ERROR, WARNING, INFO, or DEBUG. Defaults to INFO
@@ -624,7 +626,7 @@ All IAM actions under the s3 service that have the access level permissions-mana
 ### Actions for S3 service at Write access level that only support wildcard resources (*)
 
 <details open>
-<summary>policy_sentry query action-table --service s3 --access-level read --wildcard-only --fmt yaml</summary>
+<summary>policy_sentry query action-table --service s3 --access-level read --resource-type '*' --fmt yaml</summary>
 <br>
 <pre>
 <code>
@@ -640,7 +642,7 @@ s3 READ actions that must use wildcards in the resources block:
 ### Actions for S3 service at any access level that only support wildcard resources (*)
 
 <details open>
-<summary>policy_sentry query action-table --service s3 --wildcard-only --fmt yaml</summary>
+<summary>policy_sentry query action-table --service s3 --resource-type '*' --fmt yaml</summary>
 <br>
 <pre>
 <code>

--- a/tasks.py
+++ b/tasks.py
@@ -154,6 +154,10 @@ def query(c):
         c.run('./policy_sentry/bin/cli.py query action-table --service ram --name tagresource', pty=True)
         c.run('./policy_sentry/bin/cli.py query action-table '
               '--service ram --access-level permissions-management', pty=True)
+        c.run('./policy_sentry/bin/cli.py query action-table --service ssm --resource-type parameter', pty=True)
+        c.run('./policy_sentry/bin/cli.py query action-table --service ssm --access-level write '
+              '--resource-type parameter', pty=True)
+        c.run('policy_sentry query action-table --service ssm --resource-type parameter', pty=True)
         c.run('./policy_sentry/bin/cli.py query action-table --service ses --condition ses:FeedbackAddress', pty=True)
         c.run('echo "Querying the ARN table"', pty=True)
         c.run('./policy_sentry/bin/cli.py query arn-table --service ssm', pty=True)

--- a/test/querying/test_query_actions.py
+++ b/test/querying/test_query_actions.py
@@ -15,7 +15,8 @@ from policy_sentry.querying.actions import (
     get_dependent_actions,
     remove_actions_that_are_not_wildcard_arn_only,
     get_actions_matching_condition_key,
-    get_actions_matching_arn
+    get_actions_matching_arn,
+    get_actions_matching_arn_type
     # get_actions_matching_condition_crud_and_arn
 )
 from policy_sentry.writing.validate import check
@@ -202,7 +203,7 @@ class QueryActionsTestCase(unittest.TestCase):
         # )
         # print(output)
 
-    def test_get_actions_with_arn_type_and_access_level(self):
+    def test_get_actions_with_arn_type_and_access_level_case_1(self):
         """querying.actions.get_actions_with_arn_type_and_access_level"""
         desired_output = [
             's3:DeleteBucketPolicy',
@@ -216,6 +217,64 @@ class QueryActionsTestCase(unittest.TestCase):
         )
         self.maxDiff = None
         self.assertListEqual(desired_output, output)
+
+    def test_get_actions_with_arn_type_and_access_level_case_2(self):
+        """querying.actions.get_actions_with_arn_type_and_access_level with arn type"""
+        desired_output = [
+            'ssm:DeleteParameter',
+            'ssm:DeleteParameters',
+            'ssm:LabelParameterVersion',
+            'ssm:PutParameter'
+]
+        output = get_actions_with_arn_type_and_access_level(
+            "ssm", "parameter", "Write"
+        )
+        self.assertListEqual(desired_output, output)
+
+    def test_get_actions_with_arn_type_and_access_level_case_3(self):
+        """querying.actions.get_actions_with_arn_type_and_access_level with arn type"""
+        desired_output = [
+            's3:PutAccountPublicAccessBlock'
+        ]
+        output = get_actions_with_arn_type_and_access_level(
+            # "ram", "resource-share", "Write"
+            "s3", "*", "Permissions management"
+        )
+        self.assertListEqual(desired_output, output)
+
+    def test_get_actions_with_arn_type_and_access_level_case_4(self):
+        """querying.actions.get_actions_with_arn_type_and_access_level with arn type"""
+        desired_output = [
+            'secretsmanager:ListSecrets'
+        ]
+        output = get_actions_with_arn_type_and_access_level(
+            "secretsmanager", "*", "List"
+        )
+        self.assertListEqual(desired_output, output)
+
+    def test_get_actions_with_arn_type_and_access_level_case_5(self):
+        """querying.actions.get_actions_with_arn_type_and_access_level with arn type"""
+
+        output = get_actions_with_arn_type_and_access_level(
+            "all", "object", "List"
+        )
+
+        self.assertTrue(len(output) == 2)
+
+    def test_get_actions_matching_arn_type_case_1(self):
+        """querying.actions.get_actions_matching_arn_type"""
+        output = get_actions_matching_arn_type('ecr', '*')
+        self.assertEqual(output, ["ecr:GetAuthorizationToken"])
+
+    def test_get_actions_matching_arn_type_case_2(self):
+        """querying.actions.get_actions_matching_arn_type"""
+        output = get_actions_matching_arn_type('all', 'object')
+        self.assertTrue('all:AbortMultipartUpload' in output)
+
+    def test_get_actions_matching_arn_type_case_3(self):
+        """querying.actions.get_actions_matching_arn_type"""
+        output = get_actions_matching_arn_type('rds', 'object')
+        self.assertTrue(len(output) == 0)
 
     def test_get_actions_matching_condition_key(self):
         """querying.actions.get_actions_matching_condition_key"""
@@ -280,7 +339,6 @@ class QueryActionsTestCase(unittest.TestCase):
     #         "kms:EncryptionAlgorithm", "Write", "*"
     #     )
     #     self.assertListEqual(desired_results, results)
-
 
     def test_remove_actions_not_matching_access_level(self):
         # TODO: This method normalized the access level unnecessarily. Make sure to change that in the final iteration

--- a/test/querying/test_query_actions.py
+++ b/test/querying/test_query_actions.py
@@ -276,6 +276,19 @@ class QueryActionsTestCase(unittest.TestCase):
         output = get_actions_matching_arn_type('rds', 'object')
         self.assertTrue(len(output) == 0)
 
+    def test_get_actions_matching_arn_type_case_4(self):
+        """querying.actions.get_actions_matching_arn_type"""
+
+        desired_output = [
+            'codestar:CreateUserProfile',
+            'codestar:DeleteUserProfile',
+            'codestar:UpdateUserProfile'
+        ]
+
+        output = get_actions_matching_arn_type("codestar", "user")
+
+        self.assertTrue(output, desired_output)
+
     def test_get_actions_matching_condition_key(self):
         """querying.actions.get_actions_matching_condition_key"""
 


### PR DESCRIPTION
## What does this PR do?

**Address https://github.com/salesforce/policy_sentry/issues/255 with the Bonus Points**

[//]: # (Required: Describe the effects of your pull request in detail. If
multiple changes are involved, a bulleted list is often useful.)

1. Adding **--resource-type** flag to `policy_sentry query action-table`
2. Removing **--wildcard-only** flag from `policy_sentry query action-table`
3. Adding method `get_actions_matching_arn_type`
4. Modifying method `get_actions_with_arn_type_and_access_level` 
4. Adding unit tests for the new methods added and methods modified
5. Adding integration tests for new -`-resource-type` flag

## What gif best describes this PR or how it makes you feel?

[//]: # (Encouraged: Insert an appropriate gif/meme to brighten up your reviewer's day.)
![ALT](https://media.giphy.com/media/l41Ye5dhLPqILtT2w/giphy.gif)

## Completion checklist

- [x] CHANGELOG.md has been updated to reflect the changes
- [x] Additions and changes have unit tests
- [x] [Unit tests, Pylint, security testing, and Integration tests are passing.](https://github.com/salesforce/policy_sentry/actions). GitHub actions does this automatically
- [x] The pull request has been appropriately labeled using the provided PR labels
