### PR TITLE
Fix for #266 SID contains dash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Backend methods:
   * Added some utility functions (`get_statement_from_policy_using_sid`, `get_sid_names_from_policy` to make it easier to future-proof unit tests that rely on the ever-changing AWS IAM data.
   * Bug fix for `get_actions_for_service` (Fixes #245)
+  * Bug fix for `create_policy_sid_namespace` (Fixes #266)
 
 ## 0.9.0 (2020-10-01)
 * Speed improvements: The IAM definition is now a dictionary instead of a list.

--- a/policy_sentry/writing/sid_group.py
+++ b/policy_sentry/writing/sid_group.py
@@ -681,7 +681,7 @@ def create_policy_sid_namespace(
     # applies for "Permissions management"
     access_level = re.sub("[^A-Za-z0-9]+", "", access_level)
     sid_namespace_prefix = (
-        capitalize_first_character(service)
+        capitalize_first_character(strip_special_characters(service))
         + capitalize_first_character(access_level)
         + capitalize_first_character(resource_type_name)
     )

--- a/test/writing/test_sid_group_actions.py
+++ b/test/writing/test_sid_group_actions.py
@@ -20,6 +20,7 @@ class SidGroupActionsTestCase(unittest.TestCase):
             "mode": "actions",
             "name": "RoleNameWithCRUD",
             "actions": [
+                "codestar-connections:UseConnection",
                 "kms:CreateGrant",
                 "kms:CreateCustomKeyStore",
                 "ec2:AuthorizeSecurityGroupEgress",
@@ -32,6 +33,16 @@ class SidGroupActionsTestCase(unittest.TestCase):
         desired_output = {
             "Version": "2012-10-17",
             "Statement": [
+                {
+                    "Sid": "CodestarconnectionsReadConnection",
+                    "Effect": "Allow",
+                    "Action": [
+                        "codestar-connections:UseConnection"
+                    ],
+                    "Resource": [
+                        "arn:${Partition}:codestar-connections:${Region}:${Account}:connection/${ConnectionId}"
+                    ]
+                },
                 {
                     "Sid": "KmsPermissionsmanagementKey",
                     "Effect": "Allow",


### PR DESCRIPTION
Generated policy for anything containing a dash in actions based generate SID with a dash

mode: actions
name: 'RoleNameWithActions'
actions:
- access-analyzer:CreateAnalyzer

## What does this PR do?

Fix a bug when using action based policy containing a dash

## What gif best describes this PR or how it makes you feel?

![image](https://media1.giphy.com/media/3oz8xyB3C126ZDDAuk/giphy.webp)

## Completion checklist

- [x] CHANGELOG.md has been updated to reflect the changes
- [x] Additions and changes have unit tests
- [x] [Unit tests, Pylint, security testing, and Integration tests are passing.](https://github.com/salesforce/policy_sentry/actions). GitHub actions does this automatically
- [x] The pull request has been appropriately labeled using the provided PR labels

