### PR TITLE
Change minimize to a boolean flag with an option minimize-length argument

### DIFF
--- a/policy_sentry/bin/cli.py
+++ b/policy_sentry/bin/cli.py
@@ -2,7 +2,7 @@
 """
     Policy Sentry is a tool for generating least-privilege IAM Policies.
 """
-__version__ = "0.9.0"
+__version__ = "0.10.0"
 import click
 from policy_sentry import command
 

--- a/policy_sentry/command/write_policy.py
+++ b/policy_sentry/command/write_policy.py
@@ -27,14 +27,15 @@ logger = logging.getLogger(__name__)
     is_flag=True,
     required=False,
     default=False,
+    is_eager=True,
     help="Minimize the resulting statement with *safe* usage of wildcards to reduce policy length."
 )
-@click.option(
-    "--minimize-length",
+@click.argument(
+    "minimize-length",
+    nargs=1,
     type=click.IntRange(0),
     required=False,
-    default=0,
-    help="Sets the character length applied during policy minimization. Default is zero."
+    default=0
 )
 @click.option(
     "--fmt",

--- a/policy_sentry/command/write_policy.py
+++ b/policy_sentry/command/write_policy.py
@@ -27,7 +27,6 @@ logger = logging.getLogger(__name__)
     is_flag=True,
     required=False,
     default=False,
-    is_eager=True,
     help="Minimize the resulting statement with *safe* usage of wildcards to reduce policy length."
 )
 @click.argument(

--- a/policy_sentry/command/write_policy.py
+++ b/policy_sentry/command/write_policy.py
@@ -20,10 +20,10 @@ class RegisterLengthOption(click.Option):
     register_length = True
 
 class RegisterLengthOptionHelp(click.Option):
-    """ Fix the help for the _length suffix """
+    """ Translate help for the hidden _length suffix """
     def get_help_record(self, ctx):
-        help = super().get_help_record(ctx)
-        return (help[0].replace('_length ', '='),) + help[1:]
+        help_text = super().get_help_record(ctx)
+        return (help_text[0].replace('_length ', ' '),) + help_text[1:]
 
 class RegisterMinimizeLengthCommand(click.Command):
     """ Translate any opt= to opt_length= as needed """
@@ -67,7 +67,7 @@ class RegisterMinimizeLengthCommand(click.Command):
 @click.option(
     "--minimize_length",
     cls=RegisterLengthOptionHelp,
-    help="Sets the minimum character length for minimization.",
+    help="Sets the minimum character length for minimization. Defaults to zero.",
     type=click.IntRange(0),
     required=False,
     default=0

--- a/policy_sentry/command/write_policy.py
+++ b/policy_sentry/command/write_policy.py
@@ -22,12 +22,12 @@ class RegisterLengthOption(click.Option):
 class RegisterLengthOptionHelp(click.Option):
     """ Fix the help for the _length suffix """
     def get_help_record(self, ctx):
-        help = super(RegisterLengthOptionHelp, self).get_help_record(ctx)
+        help = super().get_help_record(ctx)
         return (help[0].replace('_length ', '='),) + help[1:]
 
 class RegisterMinimizeLengthCommand(click.Command):
+    """ Translate any opt= to opt_length= as needed """
     def parse_args(self, ctx, args):
-        """ Translate any opt= to opt_length= as needed """
         options = [o for o in ctx.command.params
                    if getattr(o, 'register_length', None)]
         prefixes = {p for p in sum([o.opts for o in options], [])
@@ -43,7 +43,7 @@ class RegisterMinimizeLengthCommand(click.Command):
                     if len(args) > i+1 and not args[i+1].startswith('--'):
                         value = args[i+1]
                         args[i+1] = a[0] + '_length=' + value
-        return super(RegisterMinimizeLengthCommand, self).parse_args(ctx, args)
+        return super().parse_args(ctx, args)
 
 
 @click.command(

--- a/policy_sentry/command/write_policy.py
+++ b/policy_sentry/command/write_policy.py
@@ -37,7 +37,7 @@ class RegisterMinimizeLengthCommand(click.Command):
             if a[0] in prefixes:
                 if len(a) > 1:
                     args[i] = a[0]
-                    args.append(a[0] + '_length=' + a[1])
+                    args.insert(i+1, a[0] + '_length=' + a[1])
                 else:
                     # check if next argument is naked
                     if len(args) > i+1 and not args[i+1].startswith('--'):

--- a/policy_sentry/command/write_policy.py
+++ b/policy_sentry/command/write_policy.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
     help="Path of the YAML File used for generating policies",
 )
 @click.option(
-    "--minimize/--no-minimize",
+    "--minimize",
     is_flag=True,
     required=False,
     default=False,


### PR DESCRIPTION
## What does this PR do?
Changes the --minimize option to a boolean flag.  The default is --no-minimize and does not need to be supplied on the command line.  When --minimize is supplied, the default character length is zero.  An optional --minimize-length option can be used to override and only accepts integers >= 0.

[//]: # (Required: Describe the effects of your pull request in detail. If multiple changes are involved, a bulleted list is often useful.)
- Changes --minimize to a boolean flag.  Unfortunately, this breaks compatibility.


## What gif best describes this PR or how it makes you feel?
N/A

[//]: # (Encouraged: Insert an appropriate gif/meme to brighten up your reviewer's day.)

## Completion checklist

- [ ] CHANGELOG.md has been updated to reflect the changes
- [ ] Additions and changes have unit tests
- [ ] [Unit tests, Pylint, security testing, and Integration tests are passing.](https://github.com/salesforce/policy_sentry/actions). GitHub actions does this automatically
- [ ] The pull request has been appropriately labeled using the provided PR labels
