### PR TITLE
Fixes #288 - adds abbreviated argument flags for power users

### DIFF
--- a/policy_sentry/command/create_template.py
+++ b/policy_sentry/command/create_template.py
@@ -16,13 +16,13 @@ logger = logging.getLogger(__name__)
     short_help="Create write-policy YML template files",
 )
 @click.option(
-    "--output-file",
+    "--output-file", "-o",
     type=str,
     required=True,
     help="Relative path to output file where we want to store policy_sentry YML files.",
 )
 @click.option(
-    "--template-type",
+    "--template-type", "-t",
     type=click.Choice(["actions", "crud"], case_sensitive=False),
     required=True,
     help="Type of write_policy template to create - actions or CRUD. Case insensitive.",

--- a/policy_sentry/command/initialize.py
+++ b/policy_sentry/command/initialize.py
@@ -39,8 +39,8 @@ logger = logging.getLogger(__name__)
     required=False,
     default=False,
     help="Specify this flag to fetch the HTML Docs directly from the AWS website. This will be helpful if the docs "
-    "in the Git repository are behind the live docs and you need to use the latest version of the docs right "
-    "now.",
+         "in the Git repository are behind the live docs and you need to use the latest version of the docs right "
+         "now.",
 )
 @click.option(
     "--build",
@@ -48,12 +48,12 @@ logger = logging.getLogger(__name__)
     required=False,
     default=False,
     help="Build the IAM data file from the HTML files rather than copying the data file from "
-    "the python package. Defaults to false",
+         "the python package. Defaults to false",
 )
 @click.option(
     '--verbose', '-v',
     type=click.Choice(['critical', 'error', 'warning', 'info', 'debug'],
-    case_sensitive=False))
+                      case_sensitive=False))
 def initialize_command(access_level_overrides_file, fetch, build, verbose):
     """
     CLI command for initializing the local data file

--- a/policy_sentry/command/query.py
+++ b/policy_sentry/command/query.py
@@ -39,32 +39,35 @@ def query():
 
 @query.command(
     short_help="Query the action table based on access levels, conditions, or actions that only support wildcard "
-    "resources."
+               "resources."
 )
 @click.option(
-    "--service", type=str, required=True, help="Filter according to AWS service."
+    "--service", "-s",
+    type=str,
+    required=True,
+    help="Filter according to AWS service."
 )
 @click.option(
-    "--name",
+    "--name", "-n",
     type=str,
     required=False,
     help='The name of IAM Action. For example, if the action is "iam:ListUsers", supply "ListUsers" here.',
 )
 @click.option(
-    "--access-level",
+    "--access-level", "-a",
     type=click.Choice(["read", "write", "list", "tagging", "permissions-management"]),
     required=False,
     help="Filter according to CRUD levels. "
-    "Acceptable values are read, write, list, tagging, permissions-management",
+         "Acceptable values are read, write, list, tagging, permissions-management",
 )
 @click.option(
-    "--condition",
+    "--condition", "-c",
     type=str,
     required=False,
     help="Supply a condition key to show a list of all IAM actions that support the condition key.",
 )
 @click.option(
-    "--resource-type",
+    "--resource-type", "-r",
     type=str,
     required=False,
     help="Supply a resource type to show a list of all IAM actions that support the resource type.",
@@ -79,7 +82,7 @@ def query():
 @click.option(
     '--verbose', '-v',
     type=click.Choice(['critical', 'error', 'warning', 'info', 'debug'],
-    case_sensitive=False))
+                      case_sensitive=False))
 def action_table(name, service, access_level, condition, resource_type, fmt, verbose):
     """Query the Action Table from the Policy Sentry database"""
     if verbose:
@@ -95,7 +98,8 @@ def query_action_table(
     """Query the Action Table from the Policy Sentry database.
     Use this one when leveraging Policy Sentry as a library."""
     if os.path.exists(LOCAL_DATASTORE_FILE_PATH):
-        logger.info(f"Using the Local IAM definition: {LOCAL_DATASTORE_FILE_PATH}. To leverage the bundled definition instead, remove the folder $HOME/.policy_sentry/")
+        logger.info(
+            f"Using the Local IAM definition: {LOCAL_DATASTORE_FILE_PATH}. To leverage the bundled definition instead, remove the folder $HOME/.policy_sentry/")
     else:
         # Otherwise, leverage the datastore inside the python package
         logger.debug("Leveraging the bundled IAM Definition.")
@@ -171,19 +175,22 @@ def query_action_table(
 
 @query.command(
     short_help="Query the ARN table to show RAW ARNs, like `aws:s3:::bucket/object`. "
-    "Use --list-arn-types ARN types, like `object`."
+               "Use --list-arn-types ARN types, like `object`."
 )
 @click.option(
-    "--service", type=str, required=True, help="Filter according to AWS service."
+    "--service", "-s",
+    type=str,
+    required=True,
+    help="Filter according to AWS service."
 )
 @click.option(
-    "--name",
+    "--name", "-n",
     type=str,
     required=False,
     help="The short name of the resource ARN type. For example, `bucket` under service `s3`.",
 )
 @click.option(
-    "--list-arn-types",
+    "--list-arn-types", "-l",
     is_flag=True,
     required=False,
     help="Show the short names of ARN Types. If empty, this will show RAW ARNs only.",
@@ -198,7 +205,7 @@ def query_action_table(
 @click.option(
     '--verbose', '-v',
     type=click.Choice(['critical', 'error', 'warning', 'info', 'debug'],
-    case_sensitive=False))
+                      case_sensitive=False))
 def arn_table(name, service, list_arn_types, fmt="json", verbose=None):
     """Query the ARN Table from the Policy Sentry database"""
     if verbose:
@@ -210,7 +217,8 @@ def arn_table(name, service, list_arn_types, fmt="json", verbose=None):
 def query_arn_table(name, service, list_arn_types, fmt):
     """Query the ARN Table from the Policy Sentry database. Use this one when leveraging Policy Sentry as a library."""
     if os.path.exists(LOCAL_DATASTORE_FILE_PATH):
-        logger.info(f"Using the Local IAM definition: {LOCAL_DATASTORE_FILE_PATH}. To leverage the bundled definition instead, remove the folder $HOME/.policy_sentry/")
+        logger.info(
+            f"Using the Local IAM definition: {LOCAL_DATASTORE_FILE_PATH}. To leverage the bundled definition instead, remove the folder $HOME/.policy_sentry/")
     else:
         # Otherwise, leverage the datastore inside the python package
         logger.debug("Leveraging the bundled IAM Definition.")
@@ -236,14 +244,17 @@ def query_arn_table(name, service, list_arn_types, fmt):
 
 @query.command(short_help="Query the condition table.")
 @click.option(
-    "--name",
+    "--name", "-n",
     type=str,
     required=False,
     help="Get details on a specific condition key. Leave this blank to get a list of all condition keys "
-    "available to the service.",
+         "available to the service.",
 )
 @click.option(
-    "--service", type=str, required=True, help="Filter according to AWS service."
+    "--service", "-s",
+    type=str,
+    required=True,
+    help="Filter according to AWS service."
 )
 @click.option(
     "--fmt",
@@ -255,7 +266,7 @@ def query_arn_table(name, service, list_arn_types, fmt):
 @click.option(
     '--verbose', '-v',
     type=click.Choice(['critical', 'error', 'warning', 'info', 'debug'],
-    case_sensitive=False))
+                      case_sensitive=False))
 def condition_table(name, service, fmt, verbose):
     """Query the condition table from the Policy Sentry database"""
     if verbose:
@@ -268,7 +279,8 @@ def query_condition_table(name, service, fmt="json"):
     """Query the condition table from the Policy Sentry database.
     Use this one when leveraging Policy Sentry as a library."""
     if os.path.exists(LOCAL_DATASTORE_FILE_PATH):
-        logger.info(f"Using the Local IAM definition: {LOCAL_DATASTORE_FILE_PATH}. To leverage the bundled definition instead, remove the folder $HOME/.policy_sentry/")
+        logger.info(
+            f"Using the Local IAM definition: {LOCAL_DATASTORE_FILE_PATH}. To leverage the bundled definition instead, remove the folder $HOME/.policy_sentry/")
     else:
         # Otherwise, leverage the datastore inside the python package
         logger.debug("Leveraging the bundled IAM Definition.")

--- a/policy_sentry/command/write_policy.py
+++ b/policy_sentry/command/write_policy.py
@@ -12,6 +12,7 @@ from policy_sentry import set_stream_logger
 
 logger = logging.getLogger(__name__)
 
+
 # adapted from
 # https://stackoverflow.com/questions/40753999/python-click-make-option-value-optional
 
@@ -19,14 +20,18 @@ class RegisterLengthOption(click.Option):
     """ Mark this option as getting a _length option """
     register_length = True
 
+
 class RegisterLengthOptionHelp(click.Option):
     """ Translate help for the hidden _length suffix """
+
     def get_help_record(self, ctx):
         help_text = super().get_help_record(ctx)
         return (help_text[0].replace('_length ', ' '),) + help_text[1:]
 
+
 class RegisterMinimizeLengthCommand(click.Command):
     """ Translate any opt= to opt_length= as needed """
+
     def parse_args(self, ctx, args):
         options = [o for o in ctx.command.params
                    if getattr(o, 'register_length', None)]
@@ -37,12 +42,12 @@ class RegisterMinimizeLengthCommand(click.Command):
             if a[0] in prefixes:
                 if len(a) > 1:
                     args[i] = a[0]
-                    args.insert(i+1, a[0] + '_length=' + a[1])
+                    args.insert(i + 1, a[0] + '_length=' + a[1])
                 else:
                     # check if next argument is naked
-                    if len(args) > i+1 and not args[i+1].startswith('--'):
-                        value = args[i+1]
-                        args[i+1] = a[0] + '_length=' + value
+                    if len(args) > i + 1 and not args[i + 1].startswith('--'):
+                        value = args[i + 1]
+                        args[i + 1] = a[0] + '_length=' + value
         return super().parse_args(ctx, args)
 
 
@@ -52,12 +57,12 @@ class RegisterMinimizeLengthCommand(click.Command):
 )
 # pylint: disable=duplicate-code
 @click.option(
-    "--input-file",
+    "--input-file", "-i",
     type=str,
     help="Path of the YAML File used for generating policies",
 )
 @click.option(
-    "--minimize",
+    "--minimize", "-m",
     cls=RegisterLengthOption,
     is_flag=True,
     required=False,
@@ -82,7 +87,7 @@ class RegisterMinimizeLengthCommand(click.Command):
 @click.option(
     '--verbose', '-v',
     type=click.Choice(['critical', 'error', 'warning', 'info', 'debug'],
-    case_sensitive=False))
+                      case_sensitive=False))
 def write_policy(input_file, minimize, minimize_length, fmt, verbose):
     """
     Write least-privilege IAM policies, restricting all actions to resource ARNs.
@@ -111,7 +116,7 @@ def write_policy(input_file, minimize, minimize_length, fmt, verbose):
         indent = 4 if fmt == "json" else None
         policy_str = json.dumps(policy, indent=indent)
         if fmt == "terraform":
-            obj = { 'policy': policy_str }
+            obj = {'policy': policy_str}
             policy_str = json.dumps(obj)
     print(policy_str)
 


### PR DESCRIPTION
## What does this PR do?

Adds abbreviated argument flags, which fixes #288. I had several users request this feature because it would take too long to write the commands.

Here are the new argument options:

**policy_sentry write-policy**
* `--input-file`: `-i`
* `--mimimize`: `-m`

**policy_sentry create-template**
* `--output-file`: `-o` 
* `--template-type`: `-t`

**For the query functions**:
* `--service`: `-s`
* `--name`: `-n`
* `--access-level`: `-a`
* `--condition`: `-c`
* `--resource-type`: `-r`
* `--list-arn-types`: `-l`

Note: I opted to not set an abbreviated argument flag for `--fmt` because the `-f` flag is usually used for "file". To avoid confusion, I just left it as `--fmt`

## What gif best describes this PR or how it makes you feel?

![image](https://user-images.githubusercontent.com/3422255/100761148-91ee8f00-33c0-11eb-9b27-cc96583ba036.png)

## Completion checklist

- [x] Additions and changes have unit tests
- [x] [Unit tests, Pylint, security testing, and Integration tests are passing.](https://github.com/salesforce/policy_sentry/actions). GitHub actions does this automatically
- [x] The pull request has been appropriately labeled using the provided PR labels
