### PR TITLE
Fix automatic IAM definition update action

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -4,8 +4,6 @@ on:
   schedule:
   # Run on the first day of the month
     - cron:  '0 0 1 * *'
-  push:
-    branches: ['zscholl/fix-add-path']
 
 jobs:
   update-actions:

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -4,6 +4,8 @@ on:
   schedule:
   # Run on the first day of the month
     - cron:  '0 0 1 * *'
+  push:
+    branches: ['zscholl/fix-add-path']
 
 jobs:
   update-actions:

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -31,7 +31,7 @@ jobs:
           cp -f /tmp/.policy_sentry/iam-definition.json $(pwd)/policy_sentry/shared/data/iam-definition.json
           cp -rf /tmp/.policy_sentry/data/docs $(pwd)/policy_sentry/shared/data/
       - name: PR if files were updated
-        uses: peter-evans/create-pull-request@v2
+        uses: peter-evans/create-pull-request@v3
         with:
           commit-message: Update database
           title: 'Updates database'

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -18,7 +18,7 @@ jobs:
       - name: install deps
         run: pip install requests schema PyYAML click click_log beautifulsoup4
       - name: install policy_sentry
-        run: echo "::set-env name=PYTHONPATH::$(pwd)"
+        run: echo "PYTHONPATH=$(pwd)" >> $GITHUB_ENV
       - name: Run initialize
         run: |
           python .github/scripts/update_data.py


### PR DESCRIPTION
## What does this PR do?

Fixes issue #305

The old action used the `set-env` syntax which is now deprecated. This PR updates the environment setting syntax to the new method.

See here for a test of the working action: https://github.com/zscholl/policy_sentry/actions/runs/429329418

[//]: # (Required: Describe the effects of your pull request in detail. If
multiple changes are involved, a bulleted list is often useful.)

## What gif best describes this PR or how it makes you feel?

[//]: # (Encouraged: Insert an appropriate gif/meme to brighten up your reviewer's day.)

## Completion checklist

- [ ] Additions and changes have unit tests
- [ ] [Unit tests, Pylint, security testing, and Integration tests are passing.](https://github.com/salesforce/policy_sentry/actions). GitHub actions does this automatically
- [ ] The pull request has been appropriately labeled using the provided PR labels
