### PR TITLE
Add method to get links to all AWS Actions

### DIFF
--- a/test/querying/test_query_actions.py
+++ b/test/querying/test_query_actions.py
@@ -533,4 +533,4 @@ class QueryActionsTestCase(unittest.TestCase):
     def test_get_all_links(self):
         """querying.actions.get_all_action_links"""
         results = get_all_action_links()
-        self.assertTrue(len(results.keys() > 8000))
+        self.assertTrue(len(results.keys()) > 8000)

--- a/test/querying/test_query_actions.py
+++ b/test/querying/test_query_actions.py
@@ -17,7 +17,8 @@ from policy_sentry.querying.actions import (
     get_actions_matching_condition_key,
     get_actions_matching_arn,
     get_actions_matching_arn_type,
-    get_api_documentation_link_for_action
+    get_api_documentation_link_for_action,
+    get_all_action_links
     # get_actions_matching_condition_crud_and_arn
 )
 from policy_sentry.writing.validate import check
@@ -528,3 +529,8 @@ class QueryActionsTestCase(unittest.TestCase):
         # Link should be: https://docs.aws.amazon.com/cloud9/latest/APIReference/API_CreateEnvironmentEC2.html
         # We will just check the https and subdomain.domain in case they change the format in the future.
         self.assertTrue("https://docs.aws.amazon.com" in result)
+
+    def test_get_all_links(self):
+        """querying.actions.get_all_action_links"""
+        results = get_all_action_links()
+        self.assertTrue(len(results.keys() > 8000))


### PR DESCRIPTION
## What does this PR do?

Added `get_all_action_links` method to `policy_sentry.querying.actions`

## Completion checklist

- [x] Additions and changes have unit tests
- [x] [Unit tests, Pylint, security testing, and Integration tests are passing.](https://github.com/salesforce/policy_sentry/actions). GitHub actions does this automatically
- [x] The pull request has been appropriately labeled using the provided PR labels
