### PR TITLE
Invalid ARNs now raise a descriptive exception instead of just a generic IndexError message

### DIFF
--- a/policy_sentry/util/arns.py
+++ b/policy_sentry/util/arns.py
@@ -25,14 +25,16 @@ class ARN:
         )
 
         if not follows_arn_format:
-            raise Exception("The provided value does not follow required ARN formatting.")
-        elements = self.arn.split(":", 5)
-        self.partition = elements[1]
-        self.service_prefix = elements[2]
-        self.region = elements[3]
-        self.account = elements[4]
-        self.resource = elements[5]
-
+            raise Exception("The provided value does not follow required ARN format.")
+        try:
+            elements = self.arn.split(":", 5)
+            self.partition = elements[1]
+            self.service_prefix = elements[2]
+            self.region = elements[3]
+            self.account = elements[4]
+            self.resource = elements[5]
+        except IndexError as error:
+            raise Exception("The provided ARN is invalid. IndexError: %s. Please provide a valid ARN." % error) from error
         if "/" in self.resource:
             self.resource, self.resource_path = self.resource.split("/", 1)
         elif ":" in self.resource:
@@ -156,16 +158,19 @@ def parse_arn(arn):
     """
     Given an ARN, split up the ARN into the ARN namespacing schema dictated by the AWS docs.
     """
-    elements = arn.split(":", 5)
-    result = {
-        "arn": elements[0],
-        "partition": elements[1],
-        "service": elements[2],
-        "region": elements[3],
-        "account": elements[4],
-        "resource": elements[5],
-        "resource_path": None,
-    }
+    try:
+        elements = arn.split(":", 5)
+        result = {
+            "arn": elements[0],
+            "partition": elements[1],
+            "service": elements[2],
+            "region": elements[3],
+            "account": elements[4],
+            "resource": elements[5],
+            "resource_path": None,
+        }
+    except IndexError as error:
+        raise Exception("The provided ARN is invalid. IndexError: %s. Please provide a valid ARN." % error) from error
     if "/" in result["resource"]:
         result["resource"], result["resource_path"] = result["resource"].split("/", 1)
     elif ":" in result["resource"]:

--- a/test/util/test_arns.py
+++ b/test/util/test_arns.py
@@ -1,5 +1,5 @@
 import unittest
-from policy_sentry.util.arns import does_arn_match, ARN
+from policy_sentry.util.arns import does_arn_match, ARN, parse_arn
 
 # "Does Arn Match" tests
 # See docs for this list: # https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#genref-arns
@@ -146,6 +146,11 @@ class ArnsTestCase(unittest.TestCase):
         self.assertFalse(does_arn_match(this_arn, backup))
         self.assertFalse(does_arn_match(this_arn, global_table))
 
+    def test_parse_arn(self):
+        """util.arns.parse_arn: Ensure that invalid ARNs raise a proper exception message"""
+        with self.assertRaises(Exception):
+            parse_arn("aaa")
+
 
 class ArnPathTestCase(unittest.TestCase):
     # When paths are used
@@ -154,7 +159,6 @@ class ArnPathTestCase(unittest.TestCase):
         parameter_2 = "arn:aws:ssm:::parameter/dev"
         print(parameter_1.same_resource_type(parameter_2))
         self.assertTrue(parameter_1.same_resource_type(parameter_2))
-
 
     # When confusing ARNs that look like paths but are not actually paths are used
     def test_dynamo_db_non_paths(self):


### PR DESCRIPTION
## What does this PR do?

* Just a try/except for `utils.arn.parse_arn` function and the `utils.arn.ARN` class
* Fixes #335 

## What gif best describes this PR or how it makes you feel?

![image](https://user-images.githubusercontent.com/3422255/107523706-04c77380-6b83-11eb-8fea-d76573c7a838.png)

## Completion checklist

- [x] Additions and changes have unit tests
- [x] [Unit tests, Pylint, security testing, and Integration tests are passing.](https://github.com/salesforce/policy_sentry/actions). GitHub actions does this automatically
- [x] The pull request has been appropriately labeled using the provided PR labels
