### PR TITLE
Bug/fix over permissive actions

### DIFF
--- a/docs/writing-policies/wildcard-dependent-actions.md
+++ b/docs/writing-policies/wildcard-dependent-actions.md
@@ -167,5 +167,3 @@ Notice how none of those actions are included in the resulting JSON policy outpu
     ]
 }
 ```
-
-

--- a/docs/writing-policies/wildcard-dependent-actions.md
+++ b/docs/writing-policies/wildcard-dependent-actions.md
@@ -1,0 +1,171 @@
+
+In basic CRUD mode, Policy Sentry will also include any dependent actions recommended by AWS. Dependent actions are defined as "any additional permissions that you must have, 
+in addition to the permission for the action itself, to successfully call the action." By default, these will be added with a wildcard, which could lead to a policy becoming more
+permissive than intended especially if you're not using the action that brought along the dependent one.
+
+If there is a case where you notice more actions than intended are making their way into your IAM policy, it could be because of dependent actions and there is a way to toggle this feature.
+**Note:** This only applies to dependent actions that do not match the same resource type you specify in the YAML.
+
+The `wildcard-dependent-actions` key allows you to do this. (by default, it is set to `true`)
+
+You can specify that you don't want to include dependent actions as wildcard in the resulting policy. See the examples below.
+
+### Default Behavior
+`wildcard-dependent-actions: true` or not included in the crud template.
+
+**Input**:
+
+```yaml
+mode: crud
+write:
+- arn:aws:s3:::example-org-s3-access-logs
+- arn:aws:s3:::example-org-s3-access-logs/*
+wildcard-dependent-actions: true
+```
+
+**Output**
+
+As you can see the `wildcard-dependent-actions` key is set to `true`, we are using Policy Sentry's default behavior to include dependent actions as wildcards. The resulting policy will include any dependent actions that are
+specified by AWS for the action to be called. For reference, `s3:PutReplicationConfiguration` has a dependent action `iam:PassRole` according to the documentation.
+
+Notice how we have an extra section in the resulting JSON policy output allowing `iam:PassRole` on any resource:
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "MultMultNone",
+            "Effect": "Allow",
+            "Action": [
+                "iam:PassRole"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+            "Sid": "S3WriteBucket",
+            "Effect": "Allow",
+            "Action": [
+                "s3:CreateBucket",
+                "s3:DeleteBucket",
+                "s3:DeleteBucketWebsite",
+                "s3:PutAccelerateConfiguration",
+                "s3:PutAnalyticsConfiguration",
+                "s3:PutBucketCORS",
+                "s3:PutBucketLogging",
+                "s3:PutBucketNotification",
+                "s3:PutBucketObjectLockConfiguration",
+                "s3:PutBucketOwnershipControls",
+                "s3:PutBucketRequestPayment",
+                "s3:PutBucketVersioning",
+                "s3:PutBucketWebsite",
+                "s3:PutEncryptionConfiguration",
+                "s3:PutIntelligentTieringConfiguration",
+                "s3:PutInventoryConfiguration",
+                "s3:PutLifecycleConfiguration",
+                "s3:PutMetricsConfiguration",
+                "s3:PutReplicationConfiguration"
+            ],
+            "Resource": [
+                "arn:aws:s3:::example-org-s3-access-logs"
+            ]
+        },
+        {
+            "Sid": "S3WriteObject",
+            "Effect": "Allow",
+            "Action": [
+                "s3:AbortMultipartUpload",
+                "s3:DeleteObject",
+                "s3:DeleteObjectVersion",
+                "s3:PutObject",
+                "s3:PutObjectLegalHold",
+                "s3:PutObjectRetention",
+                "s3:ReplicateDelete",
+                "s3:ReplicateObject",
+                "s3:RestoreObject"
+            ],
+            "Resource": [
+                "arn:aws:s3:::example-org-s3-access-logs/*"
+            ]
+        }
+    ]
+}
+```
+
+### Toggle Behavior
+`wildcard-dependent-actions: false`
+
+**Input**:
+
+```yaml
+mode: crud
+write:
+- arn:aws:s3:::example-org-s3-access-logs
+- arn:aws:s3:::example-org-s3-access-logs/*
+wildcard-dependent-actions: false
+```
+
+**Output**
+
+As you can see the `wildcard-dependent-actions` key is set to `false`, we are telling Policy Sentry to not include dependent actions. The resulting policy should not include any dependent actions that would normally be generated if `wildcard-dependent-actions` was set to `true` (the default):
+* `iam:PassRole`
+
+Notice how none of those actions are included in the resulting JSON policy output below:
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "S3WriteBucket",
+            "Effect": "Allow",
+            "Action": [
+                "s3:CreateBucket",
+                "s3:DeleteBucket",
+                "s3:DeleteBucketWebsite",
+                "s3:PutAccelerateConfiguration",
+                "s3:PutAnalyticsConfiguration",
+                "s3:PutBucketCORS",
+                "s3:PutBucketLogging",
+                "s3:PutBucketNotification",
+                "s3:PutBucketObjectLockConfiguration",
+                "s3:PutBucketOwnershipControls",
+                "s3:PutBucketRequestPayment",
+                "s3:PutBucketVersioning",
+                "s3:PutBucketWebsite",
+                "s3:PutEncryptionConfiguration",
+                "s3:PutIntelligentTieringConfiguration",
+                "s3:PutInventoryConfiguration",
+                "s3:PutLifecycleConfiguration",
+                "s3:PutMetricsConfiguration",
+                "s3:PutReplicationConfiguration"
+            ],
+            "Resource": [
+                "arn:aws:s3:::example-org-s3-access-logs"
+            ]
+        },
+        {
+            "Sid": "S3WriteObject",
+            "Effect": "Allow",
+            "Action": [
+                "s3:AbortMultipartUpload",
+                "s3:DeleteObject",
+                "s3:DeleteObjectVersion",
+                "s3:PutObject",
+                "s3:PutObjectLegalHold",
+                "s3:PutObjectRetention",
+                "s3:ReplicateDelete",
+                "s3:ReplicateObject",
+                "s3:RestoreObject"
+            ],
+            "Resource": [
+                "arn:aws:s3:::example-org-s3-access-logs/*"
+            ]
+        }
+    ]
+}
+```
+
+

--- a/policy_sentry/writing/template.py
+++ b/policy_sentry/writing/template.py
@@ -21,6 +21,8 @@ tagging:
 - ''
 permissions-management:
 - ''
+# Whether or not to add dependent actions if they don't have the same resource constraint (default: true)
+wildcard-dependent-actions: true
 # Actions that do not support resource constraints
 wildcard-only:
   single-actions: # standalone actions
@@ -52,6 +54,7 @@ CRUD_TEMPLATE_DICT = {
     "list": [],
     "tagging": [],
     "permissions-management": [],
+    "wildcard-dependent-actions": True,
     "wildcard-only": {
         "single-actions": [],
         "service-read": [],

--- a/policy_sentry/writing/validate.py
+++ b/policy_sentry/writing/validate.py
@@ -2,7 +2,6 @@
 Validation for the Policy Sentry YML Templates.
 """
 import logging
-from xmlrpc.client import boolean
 from schema import Optional, Schema, And, Use, SchemaError
 
 logger = logging.getLogger(__name__)

--- a/policy_sentry/writing/validate.py
+++ b/policy_sentry/writing/validate.py
@@ -2,6 +2,7 @@
 Validation for the Policy Sentry YML Templates.
 """
 import logging
+from xmlrpc.client import boolean
 from schema import Optional, Schema, And, Use, SchemaError
 
 logger = logging.getLogger(__name__)
@@ -41,6 +42,7 @@ CRUD_SCHEMA = Schema(
         Optional("list"): [str],
         Optional("permissions-management"): [str],
         Optional("tagging"): [str],
+        Optional("wildcard-dependent-actions"): bool,
         Optional("wildcard-only"): {
             Optional("single-actions"): [str],
             Optional("service-read"): [str],

--- a/test/writing/test_sid_group_crud.py
+++ b/test/writing/test_sid_group_crud.py
@@ -608,3 +608,107 @@ class SidGroupCrudTestCase(unittest.TestCase):
             ]
         }
         self.assertDictEqual(result, expected_result)
+
+    def test_crud_with_wildcard_dependent_actions_false(self):
+        cfg = {
+            "mode": "crud",
+            "name": "RoleNameWithCRUD",
+            "write": ["arn:aws:s3:::example-org-s3-access-logs"],
+            "wildcard-dependent-actions": False
+        }
+        sid_group = SidGroup()
+        output = sid_group.process_template(cfg)
+        desired_output = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Sid": "S3WriteBucket",
+                    "Effect": "Allow",
+                    "Action": [
+                        "s3:CreateBucket",
+                        "s3:DeleteBucket",
+                        "s3:DeleteBucketOwnershipControls",
+                        "s3:DeleteBucketWebsite",
+                        "s3:PutAccelerateConfiguration",
+                        "s3:PutAnalyticsConfiguration",
+                        "s3:PutBucketCORS",
+                        "s3:PutBucketLogging",
+                        "s3:PutBucketNotification",
+                        "s3:PutBucketObjectLockConfiguration",
+                        "s3:PutBucketOwnershipControls",
+                        "s3:PutBucketRequestPayment",
+                        "s3:PutBucketVersioning",
+                        "s3:PutBucketWebsite",
+                        "s3:PutEncryptionConfiguration",
+                        "s3:PutIntelligentTieringConfiguration",
+                        "s3:PutInventoryConfiguration",
+                        "s3:PutLifecycleConfiguration",
+                        "s3:PutMetricsConfiguration",
+                        "s3:PutReplicationConfiguration"
+                    ],
+                    "Resource": [
+                        "arn:aws:s3:::example-org-s3-access-logs"
+                    ]
+                }
+            ]
+        }
+        self.maxDiff = None
+        # print(json.dumps(output, indent=4))
+        self.assertDictEqual(output, desired_output)
+
+    def test_crud_with_wildcard_dependent_actions_true(self):
+        cfg = {
+            "mode": "crud",
+            "name": "RoleNameWithCRUD",
+            "write": ["arn:aws:s3:::example-org-s3-access-logs"],
+            "wildcard-dependent-actions": True
+        }
+        sid_group = SidGroup()
+        output = sid_group.process_template(cfg)
+        desired_output = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Sid": "MultMultNone",
+                    "Effect": "Allow",
+                    "Action": [
+                        "iam:PassRole"
+                    ],
+                    "Resource": [
+                        "*"
+                    ]
+                },
+                {
+                    "Sid": "S3WriteBucket",
+                    "Effect": "Allow",
+                    "Action": [
+                        "s3:CreateBucket",
+                        "s3:DeleteBucket",
+                        "s3:DeleteBucketOwnershipControls",
+                        "s3:DeleteBucketWebsite",
+                        "s3:PutAccelerateConfiguration",
+                        "s3:PutAnalyticsConfiguration",
+                        "s3:PutBucketCORS",
+                        "s3:PutBucketLogging",
+                        "s3:PutBucketNotification",
+                        "s3:PutBucketObjectLockConfiguration",
+                        "s3:PutBucketOwnershipControls",
+                        "s3:PutBucketRequestPayment",
+                        "s3:PutBucketVersioning",
+                        "s3:PutBucketWebsite",
+                        "s3:PutEncryptionConfiguration",
+                        "s3:PutIntelligentTieringConfiguration",
+                        "s3:PutInventoryConfiguration",
+                        "s3:PutLifecycleConfiguration",
+                        "s3:PutMetricsConfiguration",
+                        "s3:PutReplicationConfiguration"
+                    ],
+                    "Resource": [
+                        "arn:aws:s3:::example-org-s3-access-logs"
+                    ]
+                }
+            ]
+        }
+        self.maxDiff = None
+        # print(json.dumps(output, indent=4))
+        self.assertDictEqual(output, desired_output)


### PR DESCRIPTION
Pull request

## What does this PR do?

[//]: # (Required: Describe the effects of your pull request in detail. If
multiple changes are involved, a bulleted list is often useful.)
Adds the ability to toggle whether to include dependent actions as wildcards *if they don't share the same resource type. I had a hard time coming up with how to explain this in the crud template via a comment. We can change the wording if necessary.

I focused on addressing two specific situations I found, but there could be more this would fix.
1. S3 write on a bucket ARN would include `iam:PassRole -> Resource: *` giving the user of this policy the ability to pass any role to a service.
2. KMS write on a key ARN would incude `kms:PutKeyPolicy -> Resource: *` giving the user of this policy the ability to modify any key policy *if a default or overly permissive key policy is being used.

One thing I noticed while testing is, even if we add the action that has dependent actions to `exclude-actions` PS will still include its dependent actions. Maybe a bug?

TL;DR; In addition to adding a toggle to add dependent actions as wildcard it also moves dependent actions with the same resource into the same SID (instead of wildcard).

## What gif best describes this PR or how it makes you feel?

[//]: # (Encouraged: Insert an appropriate gif/meme to brighten up your reviewer's day.)
![image](https://user-images.githubusercontent.com/3866404/152688811-b95056c4-f3c1-4867-aefc-ee4574173ee0.png)

## Completion checklist

- [ ] Additions and changes have unit tests
- [ ] [Unit tests, Pylint, security testing, and Integration tests are passing.](https://github.com/salesforce/policy_sentry/actions). GitHub actions does this automatically
- [ ] The pull request has been appropriately labeled using the provided PR labels
