### PR TITLE
docs: add comparisons to automagic iamlive and actionhero tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Writing security-conscious IAM Policies by hand can be very tedious and ineffici
 
  * Determined to make your best effort to give users and roles the least amount of privilege you need to perform your duties, you spend way too much time combing through the AWS IAM Documentation on [Actions, Resources, and Condition Keys for AWS Services][1].
  * Your team lead encourages you to build security into your IAM Policies for product quality, but eventually you get frustrated due to project deadlines.
- * You don't have an embedded security person on your team who can write those IAM policies for you, and there's no automated tool that will automagically sense the AWS API calls that you perform and then write them for you in a least-privilege manner.
+ * You don't have an embedded security person on your team who can write those IAM policies for you, and there's no automated tool that will [automagically sense the AWS API calls that you perform](https://github.com/princespaghetti/actionhero) and then write them for you in a least-privilege manner.
  * After fantasizing about that level of automation, you realize that writing least privilege IAM Policies, seemingly out of charity, will jeopardize your ability to finish your code in time to meet project deadlines.
  * You use Managed Policies (because hey, why not) or you eyeball the names of the API calls and use wildcards instead so you can move on with your life.
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Writing security-conscious IAM Policies by hand can be very tedious and ineffici
 
  * Determined to make your best effort to give users and roles the least amount of privilege you need to perform your duties, you spend way too much time combing through the AWS IAM Documentation on [Actions, Resources, and Condition Keys for AWS Services][1].
  * Your team lead encourages you to build security into your IAM Policies for product quality, but eventually you get frustrated due to project deadlines.
- * You don't have an embedded security person on your team who can write those IAM policies for you, and there's no automated tool that will [automagically sense the AWS API calls that you perform](https://github.com/princespaghetti/actionhero) and then write them for you in a least-privilege manner.
+ * You don't have an embedded security person on your team who can write those IAM Policies for you, and there's no automated tool that will automagically sense the AWS API calls that you perform and then write them for you with Resource ARN constraints.
  * After fantasizing about that level of automation, you realize that writing least privilege IAM Policies, seemingly out of charity, will jeopardize your ability to finish your code in time to meet project deadlines.
  * You use Managed Policies (because hey, why not) or you eyeball the names of the API calls and use wildcards instead so you can move on with your life.
 

--- a/docs/appendices/comparison-to-related-tools.md
+++ b/docs/appendices/comparison-to-related-tools.md
@@ -138,6 +138,29 @@ there are some major limitations:
         not every CloudTrail action matches IAM Actions, the results are
         not always accurate.
 
+Monitoring AWS API Calls
+------------------------
+
+### actionhero
+
+-   [actionhero](https://github.com/princespaghetti/actionhero)
+
+Action Hero is a sidecar style utility to monitor the AWS API calls that your
+application makes and log out the corresponding IAM actions.
+
+Action Hero is limited in that it uses the AWS SDK's [Client Side
+Monitoring](https://docs.aws.amazon.com/sdk-for-go/api/aws/csm/) (CSM), and as
+such, cannot capture parameters or Resource ARNs. It also does not generate
+full policies; it only logs out IAM actions. Due to these limitations,
+Action Hero is not a complete tool, but can be a great addition to other tools
+as it can accurately capture all required actions.
+
+Currently, Action Hero is best suited for developing policies side-by-side with
+your application. This approach is different from the Log-based tools that
+generate policies for existing deployed applications. That being said, as a
+sidecar, Action Hero _could_ be deployed alongside applications to monitor AWS
+API calls in production.
+
 Other Infrastructure as Code Tools
 ----------------------------------
 

--- a/docs/appendices/comparison-to-related-tools.md
+++ b/docs/appendices/comparison-to-related-tools.md
@@ -141,19 +141,38 @@ there are some major limitations:
 Monitoring AWS API Calls
 ------------------------
 
+### iamlive
+
+-   [iamlive](https://github.com/iann0036/iamlive)
+
+`iamlive` is a tool that monitors AWS API calls and generates an IAM policy
+based on those.
+
+`iamlive` can either use the AWS SDK's [Client Side
+Monitoring](https://docs.aws.amazon.com/sdk-for-go/api/aws/csm/) (CSM) feature
+or an embedded proxy to track which AWS API calls are made. In CSM mode, it can
+only capture IAM Actions, but in proxy mode, it can also capture Resource ARNs.
+
+`iamlive` shares similar limitations to other tools in that it relies on an
+[unofficial mapping](https://github.com/iann0036/iam-dataset) from SDK calls to
+IAM Actions, and so can have inaccuracies.
+
+Currently, `iamlive` is mainly intended to be used in a separate terminal window
+from a currently running application. That being said, it could potentially be
+used as a sidecar alongside deployed applications.
+
 ### actionhero
 
 -   [actionhero](https://github.com/princespaghetti/actionhero)
 
 Action Hero is a sidecar style utility to monitor the AWS API calls that your
-application makes and log out the corresponding IAM actions.
+application makes and log out the corresponding IAM Actions.
 
-Action Hero is limited in that it uses the AWS SDK's [Client Side
-Monitoring](https://docs.aws.amazon.com/sdk-for-go/api/aws/csm/) (CSM), and as
-such, cannot capture parameters or Resource ARNs. It also does not generate
-full policies; it only logs out IAM actions. Due to these limitations,
-Action Hero is not a complete tool, but can be a great addition to other tools
-as it can accurately capture all required actions.
+Action Hero is limited in that it makes exclusive use of CSM, and as such,
+cannot capture parameters or Resource ARNs. It also does not generate full
+policies; it only logs out IAM Actions. Due to these limitations, Action Hero
+is not a complete tool, but can be a great addition to other tools as it can
+accurately capture all required actions.
 
 Currently, Action Hero is best suited for developing policies side-by-side with
 your application. This approach is different from the Log-based tools that

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -7,7 +7,7 @@ Writing security-conscious IAM Policies by hand can be very tedious and ineffici
 
  * Determined to make your best effort to give users and roles the least amount of privilege you need to perform your duties, you spend way too much time combing through the AWS IAM Documentation on [Actions, Resources, and Condition Keys for AWS Services][1].
  * Your team lead encourages you to build security into your IAM Policies for product quality, but eventually you get frustrated due to project deadlines.
- * You don't have an embedded security person on your team who can write those IAM policies for you, and there's no automated tool that will automagically sense the AWS API calls that you perform and then write them for you in a least-privilege manner.
+ * You don't have an embedded security person on your team who can write those IAM policies for you, and there's no automated tool that will [automagically sense the AWS API calls that you perform](https://github.com/princespaghetti/actionhero) and then write them for you in a least-privilege manner.
  * After fantasizing about that level of automation, you realize that writing least privilege IAM Policies, seemingly out of charity, will jeopardize your ability to finish your code in time to meet project deadlines.
  * You use Managed Policies (because hey, why not) or you eyeball the names of the API calls and use wildcards instead so you can move on with your life.
 


### PR DESCRIPTION
## What does this PR do?

[//]: # (Required: Describe the effects of your pull request in detail. If
multiple changes are involved, a bulleted list is often useful.)

adds [Action Hero](https://github.com/princespaghetti/actionhero) and [`iamlive`](https://github.com/iann0036/iamlive) tools to a new section in the Comparison docs
 
actionhero:
-  actionhero is a tool that actually _can_ automagically sense your
    AWS API calls
    - it is a <100 LoC sidecar that uses the AWS SDK's Client Side
      Monitoring (CSM) feature to monitor the AWS API calls that a running
      application makes
    - it does have several limitations due to using CSM though, as listed
      in the comparisons doc

- Very simple, under-the-radar tool that can be a great addition


iamlive:
- iamlive is another tool that can automagically sense AWS API calls
   - iamlive can make use of CSM or run as an embedded proxy
   - it does have similar limitations to other tools in that it relies
     on an unofficial mapping, as mentioned in the comparison
        
## What gif best describes this PR or how it makes you feel?

[//]: # (Encouraged: Insert an appropriate gif/meme to brighten up your reviewer's day.)

![giphy](https://user-images.githubusercontent.com/4970083/154814878-f3384cc3-79a2-405f-ae8f-fb0d4682cfe1.gif)

[Source](https://giphy.com/gifs/movie-guy-breath-BeLYLrX37eE6c). Return to monke? 🙈  

## Completion checklist

- [x] Additions and changes have unit tests (N/A)
- [ ] [Unit tests, Pylint, security testing, and Integration tests are passing.](https://github.com/salesforce/policy_sentry/actions). GitHub actions does this automatically
- [ ] The pull request has been appropriately labeled using the provided PR labels
