### PR TITLE
Access level overrides

### DIFF
--- a/policy_sentry/shared/constants.py
+++ b/policy_sentry/shared/constants.py
@@ -40,9 +40,15 @@ else:
     DATASTORE_FILE_PATH = BUNDLED_DATASTORE_FILE_PATH
 
 # Overrides
-BUNDLED_ACCESS_OVERRIDES_FILE = os.path.join(
-    os.path.abspath(os.path.dirname(__file__)), "data", "access-level-overrides.yml"
-)
+if "CUSTOM_ACCESS_OVERRIDES_FILE" in os.environ:
+    CUSTOM_ACCESS_OVERRIDES_FILE=os.environ['CUSTOM_ACCESS_OVERRIDES_FILE']
+    BUNDLED_ACCESS_OVERRIDES_FILE = os.path.join(
+        os.path.abspath(os.path.dirname(__file__)), CUSTOM_ACCESS_OVERRIDES_FILE
+    )
+else:
+    BUNDLED_ACCESS_OVERRIDES_FILE = os.path.join(
+        os.path.abspath(os.path.dirname(__file__)), "data", "access-level-overrides.yml"
+    )
 
 LOCAL_ACCESS_OVERRIDES_FILE = os.path.join(
     CONFIG_DIRECTORY, "access-level-overrides.yml"

--- a/policy_sentry/shared/constants.py
+++ b/policy_sentry/shared/constants.py
@@ -45,6 +45,7 @@ if "CUSTOM_ACCESS_OVERRIDES_FILE" in os.environ:
     BUNDLED_ACCESS_OVERRIDES_FILE = os.path.join(
         os.path.abspath(os.path.dirname(__file__)), CUSTOM_ACCESS_OVERRIDES_FILE
     )
+
 else:
     BUNDLED_ACCESS_OVERRIDES_FILE = os.path.join(
         os.path.abspath(os.path.dirname(__file__)), "data", "access-level-overrides.yml"


### PR DESCRIPTION
## What does this PR do?
This PR will avoid overriding IAM permissions access level classified by aws based on the user choice.
If the end user provided an enviroment variable the default override file won't be used.
 
[//]: # (Required: Describe the effects of your pull request in detail. If
multiple changes are involved, a bulleted list is often useful.)

The reason of this change is that i would like to query aws iam permissions as it's from aws documentation without overriding.
So i have added this option, where i can specify an empty file to avoid the default override file. 
For further details please refer to this opened isse --> https://github.com/salesforce/policy_sentry/issues/410 

## What gif best describes this PR or how it makes you feel?
Avoid overriding AWS IAM permissions dynamically during the initialization 

[//]: # (Encouraged: Insert an appropriate gif/meme to brighten up your reviewer's day.)

## Completion checklist

- [ x]  Additions and changes have unit tests

- [x ] [Unit tests, Pylint, security testing, and Integration tests are passing.](https://github.com/salesforce/policy_sentry/actions). GitHub actions does this automatically
- [ x] The pull request has been appropriately labeled using the provided PR labels
#410 