### PR TITLE
add query command for service data

### DIFF
--- a/policy_sentry/querying/services.py
+++ b/policy_sentry/querying/services.py
@@ -1,0 +1,19 @@
+"""
+Methods that execute specific queries against the SQLite database for the SERIVCES table.
+This supports the policy_sentry query functionality
+"""
+
+from __future__ import annotations
+
+from policy_sentry.shared.iam_data import iam_definition
+
+
+def get_services_data() -> list[dict[str, str]]:
+    return [
+        {
+            "prefix": service_prefix,
+            "service_name": data["service_name"],
+        }
+        for service_prefix, data in iam_definition.items()
+        if isinstance(data, dict)
+    ]

--- a/test/querying/test_query_services.py
+++ b/test/querying/test_query_services.py
@@ -1,0 +1,16 @@
+import unittest
+
+from policy_sentry.querying.services import get_services_data
+
+
+class QueryServicesTestCase(unittest.TestCase):
+    def test_get_services_data(self):
+        # when
+        results = get_services_data()
+
+        # then
+        self.assertGreater(len(results), 400)  # in 07/24 it was 405
+
+        # both should be a non-empty string
+        self.assertTrue(results[0]["prefix"])
+        self.assertTrue(results[0]["service_name"])


### PR DESCRIPTION
## What does this PR do?

- this adds a new `query` sub-command `service-table`
- also added for this specific output a `csv` format variant

Fixes #475

ex.
```
$ policy_sentry query service-table --fmt csv

prefix,service_name
a4b,Alexa for Business
execute-api,Amazon API Gateway
apigateway,Amazon API Gateway Management
...
```

## What gif best describes this PR or how it makes you feel?

![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExYjZpem13MWUwNmVycHQ0N2tvaXZrcWVpZXRibDM5emg5N3Y2dXY1bCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/qYytk8KxBPA1q/giphy.gif)

## Completion checklist

- [x] Additions and changes have unit tests
- [x] [Unit tests, Pylint, security testing, and Integration tests are passing.](https://github.com/salesforce/policy_sentry/actions). GitHub actions does this automatically
- [x] The pull request has been appropriately labeled using the provided PR labels
