### PR TITLE
remove AWS docs from wheel and minify JSON

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,9 +13,9 @@ repos:
     rev: v0.5.3
     hooks:
       - id: ruff
-        files: ^policy_sentry/
+        files: ^(policy_sentry/|setup.py)
       - id: ruff-format
-        files: ^policy_sentry/
+        files: ^(policy_sentry/|setup.py)
   - repo: https://github.com/Lucas-C/pre-commit-hooks-safety
     rev: v1.3.3
     hooks:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,0 @@
-include policy_sentry/py.typed
-recursive-include policy_sentry/shared *.txt *.html *.yml *.json

--- a/tasks.py
+++ b/tasks.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
+import shutil
 import sys
 import os
 import logging
 from invoke import task, Collection, UnexpectedExit, Failure
+
+from policy_sentry.shared.constants import LOCAL_HTML_DIRECTORY_PATH, BUNDLED_HTML_DIRECTORY_PATH
 
 sys.path.append(
     os.path.abspath(
@@ -63,7 +66,7 @@ def build_package(c):
 @task(pre=[build_package])
 def install_package(c):
     """Install the policy_sentry package built from the current directory contents (not PyPi)"""
-    c.run("pip3 install -q dist/policy_sentry-*.tar.gz")
+    c.run("pip3 install -q dist/policy_sentry-*.whl")
 
 
 @task
@@ -110,6 +113,9 @@ def clean_config_directory(c):
 def create_db(c):
     """Integration testing: Initialize the policy_sentry database"""
     try:
+        LOCAL_HTML_DIRECTORY_PATH.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(BUNDLED_HTML_DIRECTORY_PATH, LOCAL_HTML_DIRECTORY_PATH, dirs_exist_ok=True)
+
         initialize.initialize("")
     except UnexpectedExit as u_e:
         logger.critical(f"FAIL! UnexpectedExit: {u_e}")


### PR DESCRIPTION
## What does this PR do?

- by removing the AWS docs files we save 35mb, if someone needs them, then they can be found here or easily fetched via the `initialize` command
- the pretty print of the IAM JSON is nice for development, but not needed in the wheel

## What gif best describes this PR or how it makes you feel?

[//]: # (Encouraged: Insert an appropriate gif/meme to brighten up your reviewer's day.)

## Completion checklist

- [ ] Additions and changes have unit tests
- [x] [Unit tests, Pylint, security testing, and Integration tests are passing.](https://github.com/salesforce/policy_sentry/actions). GitHub actions does this automatically
- [x] The pull request has been appropriately labeled using the provided PR labels
