### PR TITLE
fix: correct release-drafter config and add Dependencies category

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -12,15 +12,19 @@ categories:
       - 'bug'
       - 'quick-fix'
   - title: '🧰 Maintenance'
-    label:
+    labels:
       - 'chore'
       - 'maintenance'
       - 'maintain'
       - 'cleanup'
   - title: '📝 Documentation'
-    label:
+    labels:
       - 'documentation'
       - 'docs'
+  - title: '⬆️ Dependencies'
+    collapse-after: 3
+    labels:
+      - 'dependencies'
 
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.


### PR DESCRIPTION
## Summary
- Fix `label` → `labels` typo on Maintenance and Documentation categories that caused [validation errors](https://github.com/salesforce/policy_sentry/actions/runs/24368533202/job/71166902309)
- Add a Dependencies category with `collapse-after: 3`

## Test plan
- [ ] Verify release-drafter action passes on this branch